### PR TITLE
Removing wchar test that doesn't apply on linux

### DIFF
--- a/include/boost/sort/spreadsort/spreadsort.hpp
+++ b/include/boost/sort/spreadsort/spreadsort.hpp
@@ -117,7 +117,7 @@ namespace spreadsort {
     \brief  Generic @c spreadsort variant detecting string element type so call to @c string_sort for @c std::wstrings.
     \details If the data type provided is a wstring, @c string_sort is used.
     \note Sorting other data types requires picking between @c integer_sort, @c float_sort and @c string_sort directly,
-    as @c spreadsort won't accept types that don't have the appropriate @c type_traits.
+    as @c spreadsort won't accept types that don't have the appropriate @c type_traits.  Also, 2-byte wide-characters are the limit above which string_sort is inefficient, so on platforms with wider characters, this will not accept wstrings.
 
     \param[in] first Iterator pointer to first element.
     \param[in] last Iterator pointing to one beyond the end of data.
@@ -132,10 +132,11 @@ namespace spreadsort {
   template <class RandomAccessIter>
   inline typename boost::enable_if_c<
     is_same<typename std::iterator_traits<RandomAccessIter>::value_type,
-            typename std::wstring>::value, void >::type
+            typename std::wstring>::value &&
+    sizeof(wchar_t) == 2, void >::type
   spreadsort(RandomAccessIter first, RandomAccessIter last)
   {
-    unsigned wchar_t unused = '\0';
+    boost::uint16_t unused = 0;
     string_sort(first, last, unused);
   }
 } // namespace spreadsort

--- a/test/string_sort_test.cpp
+++ b/test/string_sort_test.cpp
@@ -134,53 +134,6 @@ void string_test()
   BOOST_CHECK(test_vec == sorted_vec);  
 }
 
-void wstring_test()
-{
-  // Prepare inputs
-  vector<wstring> base_vec;
-  const unsigned max_length = 32;
-  srand(1);
-  //Generating semirandom numbers
-  for (unsigned u = 0; u < input_count; ++u) {
-    unsigned length = rand() % max_length;
-    wstring result;
-    for (unsigned u = 0; u < length; ++u) {
-      wchar_t val = ((rand() % 256) << 8) + rand() % 256;
-      result.push_back(val);
-    }
-    base_vec.push_back(result);
-  }
-  vector<wstring> sorted_vec = base_vec;
-  vector<wstring> test_vec = base_vec;
-  std::sort(sorted_vec.begin(), sorted_vec.end());
-  //Testing basic call
-  unsigned wchar_t unused = '\0';
-  string_sort(test_vec.begin(), test_vec.end(), unused);
-  BOOST_CHECK(test_vec == sorted_vec);
-  //Testing boost::sort::spreadsort wrapper
-  boost::sort::spreadsort::spreadsort(test_vec.begin(), test_vec.end());
-  BOOST_CHECK(test_vec == sorted_vec);
-  //Character functors
-  test_vec = base_vec;
-  string_sort(test_vec.begin(), test_vec.end(), wbracket(), wget_size());
-  BOOST_CHECK(test_vec == sorted_vec);
-  //All functors
-  test_vec = base_vec;
-  string_sort(test_vec.begin(), test_vec.end(), wbracket(), wget_size(),
-              less<wstring>());
-  BOOST_CHECK(test_vec == sorted_vec);
-  //reverse order
-  std::sort(sorted_vec.begin(), sorted_vec.end(), greater<wstring>());
-  reverse_string_sort(test_vec.begin(), test_vec.end(), greater<wstring>(), 
-                      unused);
-  BOOST_CHECK(test_vec == sorted_vec);
-  //reverse order with functors
-  test_vec = base_vec;
-  reverse_string_sort(test_vec.begin(), test_vec.end(), wbracket(), wget_size(),
-                      greater<wstring>());
-  BOOST_CHECK(test_vec == sorted_vec);  
-}
-
 // Verify that 0, 1, and input_count empty strings all sort correctly.
 void corner_test() {
   vector<string> test_vec;
@@ -202,7 +155,6 @@ int test_main( int, char*[] )
   update_offset_test();
   offset_comparison_test();
   string_test();
-  wstring_test();
   corner_test();
   return 0;
 }


### PR DESCRIPTION
Requiring 2-byte wchar_ts for spreadsort direct call.