### PR TITLE
Switch fallback sort from std::sort to pdqsort

### DIFF
--- a/include/boost/sort/spreadsort/detail/constants.hpp
+++ b/include/boost/sort/spreadsort/detail/constants.hpp
@@ -27,7 +27,7 @@ int_log_mean_bin_size = 2,
 //Minimum value 1
 int_log_min_split_count = 9,
 //This is the minimum split count to use spreadsort when it will finish in one
-//iteration.  Make this larger the faster std::sort is relative to integer_sort.
+//iteration.  Make this larger the faster boost::sort::pdqsort is relative to integer_sort.
 int_log_finishing_count = 31,
 //Sets the minimum number of items per bin for floating point.
 float_log_mean_bin_size = 2,
@@ -35,7 +35,7 @@ float_log_mean_bin_size = 2,
 //Minimum value 1
 float_log_min_split_count = 8,
 //This is the minimum split count to use spreadsort when it will finish in one
-//iteration.  Make this larger the faster std::sort is relative to float_sort.
+//iteration.  Make this larger the faster boost::sort::pdqsort is relative to float_sort.
 float_log_finishing_count = 4,
 //There is a minimum size below which it is not worth using spreadsort
 min_sort_size = 1000 };

--- a/include/boost/sort/spreadsort/detail/float_sort.hpp
+++ b/include/boost/sort/spreadsort/detail/float_sort.hpp
@@ -212,7 +212,7 @@ namespace spreadsort {
         if (count < 2)
           continue;
         if (count < max_count)
-          std::sort(lastPos, bin_cache[u]);
+          boost::sort::pdqsort(lastPos, bin_cache[u]);
         else
           positive_float_sort_rec<RandomAccessIter, Div_type, Size_type>
             (lastPos, bin_cache[u], bin_cache, cache_end, bin_sizes);
@@ -273,7 +273,7 @@ namespace spreadsort {
         if (count < 2)
           continue;
         if (count < max_count)
-          std::sort(lastPos, bin_cache[ii]);
+          boost::sort::pdqsort(lastPos, bin_cache[ii]);
         else
           negative_float_sort_rec<RandomAccessIter, Div_type, Size_type>
             (lastPos, bin_cache[ii], bin_cache, cache_end, bin_sizes);
@@ -332,7 +332,7 @@ namespace spreadsort {
         if (count < 2)
           continue;
         if (count < max_count)
-          std::sort(lastPos, bin_cache[ii]);
+          boost::sort::pdqsort(lastPos, bin_cache[ii]);
         else
           negative_float_sort_rec<RandomAccessIter, Div_type, Right_shift,
                                   Size_type>
@@ -390,7 +390,7 @@ namespace spreadsort {
         if (count < 2)
           continue;
         if (count < max_count)
-          std::sort(lastPos, bin_cache[ii], comp);
+          boost::sort::pdqsort(lastPos, bin_cache[ii], comp);
         else
           negative_float_sort_rec<RandomAccessIter, Div_type, Right_shift,
                                   Compare, Size_type>(lastPos, bin_cache[ii],
@@ -475,7 +475,7 @@ namespace spreadsort {
         if (count < 2)
           continue;
         if (count < max_count)
-          std::sort(lastPos, bin_cache[ii]);
+          boost::sort::pdqsort(lastPos, bin_cache[ii]);
         //sort negative values using reversed-bin spreadsort
         else
           negative_float_sort_rec<RandomAccessIter, Div_type, Size_type>
@@ -488,7 +488,7 @@ namespace spreadsort {
         if (count < 2)
           continue;
         if (count < max_count)
-          std::sort(lastPos, bin_cache[u]);
+          boost::sort::pdqsort(lastPos, bin_cache[u]);
         //sort positive values using normal spreadsort
         else
           positive_float_sort_rec<RandomAccessIter, Div_type, Size_type>
@@ -571,7 +571,7 @@ namespace spreadsort {
         if (count < 2)
           continue;
         if (count < max_count)
-          std::sort(lastPos, bin_cache[ii]);
+          boost::sort::pdqsort(lastPos, bin_cache[ii]);
         //sort negative values using reversed-bin spreadsort
         else
           negative_float_sort_rec<RandomAccessIter, Div_type,
@@ -585,7 +585,7 @@ namespace spreadsort {
         if (count < 2)
           continue;
         if (count < max_count)
-          std::sort(lastPos, bin_cache[u]);
+          boost::sort::pdqsort(lastPos, bin_cache[u]);
         //sort positive values using normal spreadsort
         else
           spreadsort_rec<RandomAccessIter, Div_type, Right_shift, Size_type,
@@ -670,7 +670,7 @@ namespace spreadsort {
         if (count < 2)
           continue;
         if (count < max_count)
-          std::sort(lastPos, bin_cache[ii], comp);
+          boost::sort::pdqsort(lastPos, bin_cache[ii], comp);
         //sort negative values using reversed-bin spreadsort
         else
           negative_float_sort_rec<RandomAccessIter, Div_type, Right_shift,
@@ -685,7 +685,7 @@ namespace spreadsort {
         if (count < 2)
           continue;
         if (count < max_count)
-          std::sort(lastPos, bin_cache[u], comp);
+          boost::sort::pdqsort(lastPos, bin_cache[u], comp);
         //sort positive values using normal spreadsort
         else
           spreadsort_rec<RandomAccessIter, Div_type, Right_shift, Compare,
@@ -741,7 +741,7 @@ namespace spreadsort {
       sizeof(typename std::iterator_traits<RandomAccessIter>::value_type))
       || !std::numeric_limits<typename
       std::iterator_traits<RandomAccessIter>::value_type>::is_iec559);
-      std::sort(first, last);
+      boost::sort::pdqsort(first, last);
     }
 
     //These approaches require the user to do the typecast
@@ -771,7 +771,7 @@ namespace spreadsort {
         (first, last, bin_cache, 0, bin_sizes, rshift);
     }
 
-    //sizeof(Div_type) doesn't match, so use std::sort
+    //sizeof(Div_type) doesn't match, so use boost::sort::pdqsort
     template <class RandomAccessIter, class Div_type, class Right_shift>
     inline typename boost::disable_if_c< sizeof(boost::uintmax_t) >=
       sizeof(Div_type), void >::type
@@ -779,7 +779,7 @@ namespace spreadsort {
                Right_shift rshift)
     {
       BOOST_STATIC_WARNING(sizeof(boost::uintmax_t) >= sizeof(Div_type));
-      std::sort(first, last);
+      boost::sort::pdqsort(first, last);
     }
 
     //specialized comparison
@@ -812,7 +812,7 @@ namespace spreadsort {
         (first, last, bin_cache, 0, bin_sizes, rshift, comp);
     }
 
-    //sizeof(Div_type) doesn't match, so use std::sort
+    //sizeof(Div_type) doesn't match, so use boost::sort::pdqsort
     template <class RandomAccessIter, class Div_type, class Right_shift,
               class Compare>
     inline typename boost::disable_if_c< sizeof(boost::uintmax_t) >=
@@ -821,7 +821,7 @@ namespace spreadsort {
                Right_shift rshift, Compare comp)
     {
       BOOST_STATIC_WARNING(sizeof(boost::uintmax_t) >= sizeof(Div_type));
-      std::sort(first, last, comp);
+      boost::sort::pdqsort(first, last, comp);
     }
   }
 }

--- a/include/boost/sort/spreadsort/detail/integer_sort.hpp
+++ b/include/boost/sort/spreadsort/detail/integer_sort.hpp
@@ -186,9 +186,9 @@ namespace spreadsort {
         //don't sort unless there are at least two items to Compare
         if (count < 2)
           continue;
-        //using std::sort if its worst-case is better
+        //using boost::sort::pdqsort if its worst-case is better
         if (count < max_count)
-          std::sort(lastPos, bin_cache[u]);
+          boost::sort::pdqsort(lastPos, bin_cache[u]);
         else
           spreadsort_rec<RandomAccessIter, Div_type, Size_type>(lastPos,
                                                                  bin_cache[u],
@@ -294,7 +294,7 @@ namespace spreadsort {
         if (count < 2)
           continue;
         if (count < max_count)
-          std::sort(lastPos, bin_cache[u], comp);
+          boost::sort::pdqsort(lastPos, bin_cache[u], comp);
         else
           spreadsort_rec<RandomAccessIter, Div_type, Right_shift, Compare,
         Size_type, log_mean_bin_size, log_min_split_count, log_finishing_count>
@@ -351,7 +351,7 @@ namespace spreadsort {
         if (count < 2)
           continue;
         if (count < max_count)
-          std::sort(lastPos, bin_cache[u]);
+          boost::sort::pdqsort(lastPos, bin_cache[u]);
         else
           spreadsort_rec<RandomAccessIter, Div_type, Right_shift, Size_type,
           log_mean_bin_size, log_min_split_count, log_finishing_count>(lastPos,
@@ -388,12 +388,12 @@ namespace spreadsort {
     template <class RandomAccessIter, class Div_type>
     inline typename boost::disable_if_c< sizeof(Div_type) <= sizeof(size_t)
       || sizeof(Div_type) <= sizeof(boost::uintmax_t), void >::type
-    //defaulting to std::sort when integer_sort won't work
+    //defaulting to boost::sort::pdqsort when integer_sort won't work
     integer_sort(RandomAccessIter first, RandomAccessIter last, Div_type)
     {
-      //Warning that we're using std::sort, even though integer_sort was called
+      //Warning that we're using boost::sort::pdqsort, even though integer_sort was called
       BOOST_STATIC_WARNING( sizeof(Div_type) <= sizeof(size_t) );
-      std::sort(first, last);
+      boost::sort::pdqsort(first, last);
     }
 
 
@@ -434,13 +434,13 @@ namespace spreadsort {
               class Compare>
     inline typename boost::disable_if_c< sizeof(Div_type) <= sizeof(size_t)
       || sizeof(Div_type) <= sizeof(boost::uintmax_t), void >::type
-    //defaulting to std::sort when integer_sort won't work
+    //defaulting to boost::sort::pdqsort when integer_sort won't work
     integer_sort(RandomAccessIter first, RandomAccessIter last, Div_type,
                 Right_shift shift, Compare comp)
     {
-      //Warning that we're using std::sort, even though integer_sort was called
+      //Warning that we're using boost::sort::pdqsort, even though integer_sort was called
       BOOST_STATIC_WARNING( sizeof(Div_type) <= sizeof(size_t) );
-      std::sort(first, last, comp);
+      boost::sort::pdqsort(first, last, comp);
     }
 
 
@@ -478,13 +478,13 @@ namespace spreadsort {
     template <class RandomAccessIter, class Div_type, class Right_shift>
     inline typename boost::disable_if_c< sizeof(Div_type) <= sizeof(size_t)
       || sizeof(Div_type) <= sizeof(boost::uintmax_t), void >::type
-    //defaulting to std::sort when integer_sort won't work
+    //defaulting to boost::sort::pdqsort when integer_sort won't work
     integer_sort(RandomAccessIter first, RandomAccessIter last, Div_type,
                 Right_shift shift)
     {
-      //Warning that we're using std::sort, even though integer_sort was called
+      //Warning that we're using boost::sort::pdqsort, even though integer_sort was called
       BOOST_STATIC_WARNING( sizeof(Div_type) <= sizeof(size_t) );
-      std::sort(first, last);
+      boost::sort::pdqsort(first, last);
     }
   }
 }

--- a/include/boost/sort/spreadsort/detail/spreadsort_common.hpp
+++ b/include/boost/sort/spreadsort/detail/spreadsort_common.hpp
@@ -22,6 +22,7 @@ Phil Endecott and Frank Gennari
 #include <functional>
 #include <boost/static_assert.hpp>
 #include <boost/serialization/static_warning.hpp>
+#include <boost/sort/pdqsort/pdqsort.hpp>
 #include <boost/sort/spreadsort/detail/constants.hpp>
 #include <boost/cstdint.hpp>
 

--- a/include/boost/sort/spreadsort/detail/string_sort.hpp
+++ b/include/boost/sort/spreadsort/detail/string_sort.hpp
@@ -251,9 +251,9 @@ namespace spreadsort {
         //don't sort unless there are at least two items to Compare
         if (count < 2)
           continue;
-        //using std::sort if its worst-case is better
+        //using boost::sort::pdqsort if its worst-case is better
         if (count < max_size)
-          std::sort(lastPos, bin_cache[u],
+          boost::sort::pdqsort(lastPos, bin_cache[u],
               offset_less_than<Data_type, Unsigned_char_type>(char_offset + 1));
         else
           string_sort_rec<RandomAccessIter, Unsigned_char_type>(lastPos,
@@ -362,9 +362,9 @@ namespace spreadsort {
         //don't sort unless there are at least two items to Compare
         if (count < 2)
           continue;
-        //using std::sort if its worst-case is better
+        //using boost::sort::pdqsort if its worst-case is better
         if (count < max_size)
-          std::sort(lastPos, bin_cache[u], offset_greater_than<Data_type,
+          boost::sort::pdqsort(lastPos, bin_cache[u], offset_greater_than<Data_type,
                     Unsigned_char_type>(char_offset + 1));
         else
           reverse_string_sort_rec<RandomAccessIter, Unsigned_char_type>
@@ -464,9 +464,9 @@ namespace spreadsort {
         //don't sort unless there are at least two items to Compare
         if (count < 2)
           continue;
-        //using std::sort if its worst-case is better
+        //using boost::sort::pdqsort if its worst-case is better
         if (count < max_size)
-          std::sort(lastPos, bin_cache[u], offset_char_less_than<Data_type,
+          boost::sort::pdqsort(lastPos, bin_cache[u], offset_char_less_than<Data_type,
                     Get_char, Get_length>(char_offset + 1));
         else
           string_sort_rec<RandomAccessIter, Unsigned_char_type, Get_char,
@@ -565,9 +565,9 @@ namespace spreadsort {
         //don't sort unless there are at least two items to Compare
         if (count < 2)
           continue;
-        //using std::sort if its worst-case is better
+        //using boost::sort::pdqsort if its worst-case is better
         if (count < max_size)
-          std::sort(lastPos, bin_cache[u], comp);
+          boost::sort::pdqsort(lastPos, bin_cache[u], comp);
         else
           string_sort_rec<RandomAccessIter, Unsigned_char_type, Get_char,
                           Get_length, Compare>
@@ -670,9 +670,9 @@ namespace spreadsort {
         //don't sort unless there are at least two items to Compare
         if (count < 2)
           continue;
-        //using std::sort if its worst-case is better
+        //using boost::sort::pdqsort if its worst-case is better
         if (count < max_size)
-          std::sort(lastPos, bin_cache[u], comp);
+          boost::sort::pdqsort(lastPos, bin_cache[u], comp);
         else
           reverse_string_sort_rec<RandomAccessIter, Unsigned_char_type,
                                   Get_char, Get_length, Compare>
@@ -700,9 +700,9 @@ namespace spreadsort {
     string_sort(RandomAccessIter first, RandomAccessIter last,
                 Unsigned_char_type)
     {
-      //Warning that we're using std::sort, even though string_sort was called
+      //Warning that we're using boost::sort::pdqsort, even though string_sort was called
       BOOST_STATIC_WARNING( sizeof(Unsigned_char_type) <= 2 );
-      std::sort(first, last);
+      boost::sort::pdqsort(first, last);
     }
 
     //Holds the bin vector and makes the initial recursive call
@@ -726,9 +726,9 @@ namespace spreadsort {
     {
       typedef typename std::iterator_traits<RandomAccessIter>::value_type
         Data_type;
-      //Warning that we're using std::sort, even though string_sort was called
+      //Warning that we're using boost::sort::pdqsort, even though string_sort was called
       BOOST_STATIC_WARNING( sizeof(Unsigned_char_type) <= 2 );
-      std::sort(first, last, std::greater<Data_type>());
+      boost::sort::pdqsort(first, last, std::greater<Data_type>());
     }
 
     //Holds the bin vector and makes the initial recursive call
@@ -752,9 +752,9 @@ namespace spreadsort {
     string_sort(RandomAccessIter first, RandomAccessIter last,
                 Get_char get_character, Get_length length, Unsigned_char_type)
     {
-      //Warning that we're using std::sort, even though string_sort was called
+      //Warning that we're using boost::sort::pdqsort, even though string_sort was called
       BOOST_STATIC_WARNING( sizeof(Unsigned_char_type) <= 2 );
-      std::sort(first, last);
+      boost::sort::pdqsort(first, last);
     }
 
     //Holds the bin vector and makes the initial recursive call
@@ -780,9 +780,9 @@ namespace spreadsort {
     string_sort(RandomAccessIter first, RandomAccessIter last,
         Get_char get_character, Get_length length, Compare comp, Unsigned_char_type)
     {
-      //Warning that we're using std::sort, even though string_sort was called
+      //Warning that we're using boost::sort::pdqsort, even though string_sort was called
       BOOST_STATIC_WARNING( sizeof(Unsigned_char_type) <= 2 );
-      std::sort(first, last, comp);
+      boost::sort::pdqsort(first, last, comp);
     }
 
     //Holds the bin vector and makes the initial recursive call
@@ -807,9 +807,9 @@ namespace spreadsort {
     reverse_string_sort(RandomAccessIter first, RandomAccessIter last,
         Get_char get_character, Get_length length, Compare comp, Unsigned_char_type)
     {
-      //Warning that we're using std::sort, even though string_sort was called
+      //Warning that we're using boost::sort::pdqsort, even though string_sort was called
       BOOST_STATIC_WARNING( sizeof(Unsigned_char_type) <= 2 );
-      std::sort(first, last, comp);
+      boost::sort::pdqsort(first, last, comp);
     }
   }
 }

--- a/include/boost/sort/spreadsort/float_sort.hpp
+++ b/include/boost/sort/spreadsort/float_sort.hpp
@@ -87,7 +87,7 @@ Some performance plots of runtime vs. n and log(range) are provided:\n
   inline void float_sort(RandomAccessIter first, RandomAccessIter last)
   {
     if (last - first < detail::min_sort_size)
-      std::sort(first, last);
+      boost::sort::pdqsort(first, last);
     else
       detail::float_sort(first, last);
   }
@@ -117,7 +117,7 @@ Some performance plots of runtime vs. n and log(range) are provided:\n
                          Right_shift rshift)
   {
     if (last - first < detail::min_sort_size)
-      std::sort(first, last);
+      boost::sort::pdqsort(first, last);
     else
       detail::float_sort(first, last, rshift(*first, 0), rshift);
   }
@@ -150,7 +150,7 @@ Some performance plots of runtime vs. n and log(range) are provided:\n
                          Right_shift rshift, Compare comp)
   {
     if (last - first < detail::min_sort_size)
-      std::sort(first, last, comp);
+      boost::sort::pdqsort(first, last, comp);
     else
       detail::float_sort(first, last, rshift(*first, 0), rshift, comp);
   }

--- a/include/boost/sort/spreadsort/integer_sort.hpp
+++ b/include/boost/sort/spreadsort/integer_sort.hpp
@@ -34,7 +34,7 @@ namespace spreadsort {
 
 
 /*! \brief Integer sort algorithm using random access iterators.
-  (All variants fall back to @c std::sort if the data size is too small, < @c detail::min_sort_size).
+  (All variants fall back to @c boost::sort::pdqsort if the data size is too small, < @c detail::min_sort_size).
 
   \details @c integer_sort is a fast templated in-place hybrid radix/comparison algorithm,
 which in testing tends to be roughly 50% to 2X faster than @c std::sort for large tests (>=100kB).\n
@@ -77,13 +77,13 @@ Some performance plots of runtime vs. n and log(range) are provided:\n
   {
     // Don't sort if it's too small to optimize.
     if (last - first < detail::min_sort_size)
-      std::sort(first, last);
+      boost::sort::pdqsort(first, last);
     else
       detail::integer_sort(first, last, *first >> 0);
   }
 
 /*! \brief Integer sort algorithm using range.
-  (All variants fall back to @c std::sort if the data size is too small, < @c detail::min_sort_size).
+  (All variants fall back to @c boost::sort::pdqsort if the data size is too small, < @c detail::min_sort_size).
 
   \details @c integer_sort is a fast templated in-place hybrid radix/comparison algorithm,
 which in testing tends to be roughly 50% to 2X faster than @c std::sort for large tests (>=100kB).\n
@@ -123,7 +123,7 @@ inline void integer_sort(Range& range)
 }
 
 /*! \brief Integer sort algorithm using random access iterators with both right-shift and user-defined comparison operator.
-  (All variants fall back to @c std::sort if the data size is too small, < @c detail::min_sort_size).
+  (All variants fall back to @c boost::sort::pdqsort if the data size is too small, < @c detail::min_sort_size).
 
   \details @c integer_sort is a fast templated in-place hybrid radix/comparison algorithm,
 which in testing tends to be roughly 50% to 2X faster than @c std::sort for large tests (>=100kB).\n
@@ -166,13 +166,13 @@ Some performance plots of runtime vs. n and log(range) are provided:\n
   inline void integer_sort(RandomAccessIter first, RandomAccessIter last,
                            Right_shift shift, Compare comp) {
     if (last - first < detail::min_sort_size)
-      std::sort(first, last, comp);
+      boost::sort::pdqsort(first, last, comp);
     else
       detail::integer_sort(first, last, shift(*first, 0), shift, comp);
   }
 
 /*! \brief Integer sort algorithm using range with both right-shift and user-defined comparison operator.
-  (All variants fall back to @c std::sort if the data size is too small, < @c detail::min_sort_size).
+  (All variants fall back to @c boost::sort::pdqsort if the data size is too small, < @c detail::min_sort_size).
 
   \details @c integer_sort is a fast templated in-place hybrid radix/comparison algorithm,
 which in testing tends to be roughly 50% to 2X faster than @c std::sort for large tests (>=100kB).\n
@@ -216,7 +216,7 @@ inline void integer_sort(Range& range, Right_shift shift, Compare comp)
 }
 
 /*! \brief Integer sort algorithm using random access iterators with just right-shift functor.
-  (All variants fall back to @c std::sort if the data size is too small, < @c detail::min_sort_size).
+  (All variants fall back to @c boost::sort::pdqsort if the data size is too small, < @c detail::min_sort_size).
 
   \details @c integer_sort is a fast templated in-place hybrid radix/comparison algorithm,
 which in testing tends to be roughly 50% to 2X faster than @c std::sort for large tests (>=100kB).\n
@@ -259,14 +259,14 @@ Some performance plots of runtime vs. n and log(range) are provided:\n
   inline void integer_sort(RandomAccessIter first, RandomAccessIter last,
                            Right_shift shift) {
     if (last - first < detail::min_sort_size)
-      std::sort(first, last);
+      boost::sort::pdqsort(first, last);
     else
       detail::integer_sort(first, last, shift(*first, 0), shift);
   }
 
 
 /*! \brief Integer sort algorithm using range with just right-shift functor.
-  (All variants fall back to @c std::sort if the data size is too small, < @c detail::min_sort_size).
+  (All variants fall back to @c boost::sort::pdqsort if the data size is too small, < @c detail::min_sort_size).
 
   \details @c integer_sort is a fast templated in-place hybrid radix/comparison algorithm,
 which in testing tends to be roughly 50% to 2X faster than @c std::sort for large tests (>=100kB).\n

--- a/include/boost/sort/spreadsort/string_sort.hpp
+++ b/include/boost/sort/spreadsort/string_sort.hpp
@@ -29,7 +29,7 @@ namespace sort {
 namespace spreadsort {
 
 /*! \brief String sort algorithm using random access iterators, allowing character-type overloads.\n
-  (All variants fall back to @c std::sort if the data size is too small, < @c detail::min_sort_size).
+  (All variants fall back to @c boost::sort::pdqsort if the data size is too small, < @c detail::min_sort_size).
 
   \details @c string_sort is a fast templated in-place hybrid radix/comparison algorithm,
 which in testing tends to be roughly 50% to 2X faster than @c std::sort for large tests (>=100kB).\n
@@ -76,13 +76,13 @@ Some performance plots of runtime vs. n and log(range) are provided:\n
   {
     //Don't sort if it's too small to optimize
     if (last - first < detail::min_sort_size)
-      std::sort(first, last);
+      boost::sort::pdqsort(first, last);
     else
       detail::string_sort(first, last, unused);
   }
 
 /*! \brief String sort algorithm using range, allowing character-type overloads.\n
-  (All variants fall back to @c std::sort if the data size is too small, < @c detail::min_sort_size).
+  (All variants fall back to @c boost::sort::pdqsort if the data size is too small, < @c detail::min_sort_size).
 
   \details @c string_sort is a fast templated in-place hybrid radix/comparison algorithm,
 which in testing tends to be roughly 50% to 2X faster than @c std::sort for large tests (>=100kB).\n
@@ -124,7 +124,7 @@ inline void string_sort(Range& range, Unsigned_char_type unused)
 }
 
 /*! \brief String sort algorithm using random access iterators, wraps using default of unsigned char.
-  (All variants fall back to @c std::sort if the data size is too small, < @c detail::min_sort_size).
+  (All variants fall back to @c boost::sort::pdqsort if the data size is too small, < @c detail::min_sort_size).
 
   \details @c string_sort is a fast templated in-place hybrid radix/comparison algorithm,
 which in testing tends to be roughly 50% to 2X faster than @c std::sort for large tests (>=100kB).\n
@@ -169,7 +169,7 @@ Some performance plots of runtime vs. n and log(range) are provided:\n
   }
 
 /*! \brief String sort algorithm using range, wraps using default of unsigned char.
-  (All variants fall back to @c std::sort if the data size is too small, < @c detail::min_sort_size).
+  (All variants fall back to @c boost::sort::pdqsort if the data size is too small, < @c detail::min_sort_size).
 
   \details @c string_sort is a fast templated in-place hybrid radix/comparison algorithm,
 which in testing tends to be roughly 50% to 2X faster than @c std::sort for large tests (>=100kB).\n
@@ -209,7 +209,7 @@ inline void string_sort(Range& range)
 
 /*! \brief String sort algorithm using random access iterators, allowing character-type overloads.
 
-  (All variants fall back to @c std::sort if the data size is too small, < detail::min_sort_size).
+  (All variants fall back to @c boost::sort::pdqsort if the data size is too small, < detail::min_sort_size).
 
   \details @c string_sort is a fast templated in-place hybrid radix/comparison algorithm,
 which in testing tends to be roughly 50% to 2X faster than @c std::sort for large tests (>=100kB).\n
@@ -260,14 +260,14 @@ Some performance plots of runtime vs. n and log(range) are provided:\n
   {
     //Don't sort if it's too small to optimize.
     if (last - first < detail::min_sort_size)
-      std::sort(first, last, comp);
+      boost::sort::pdqsort(first, last, comp);
     else
       detail::reverse_string_sort(first, last, unused);
   }
 
 /*! \brief String sort algorithm using range, allowing character-type overloads.
 
-  (All variants fall back to @c std::sort if the data size is too small, < detail::min_sort_size).
+  (All variants fall back to @c boost::sort::pdqsort if the data size is too small, < detail::min_sort_size).
 
   \details @c string_sort is a fast templated in-place hybrid radix/comparison algorithm,
 which in testing tends to be roughly 50% to 2X faster than @c std::sort for large tests (>=100kB).\n
@@ -314,7 +314,7 @@ inline void reverse_string_sort(Range& range, Compare comp, Unsigned_char_type u
 
 /*! \brief String sort algorithm using random access iterators,  wraps using default of @c unsigned char.
 
-  (All variants fall back to @c std::sort if the data size is too small, < @c detail::min_sort_size).
+  (All variants fall back to @c boost::sort::pdqsort if the data size is too small, < @c detail::min_sort_size).
 
   \details @c string_sort is a fast templated in-place hybrid radix/comparison algorithm,
 which in testing tends to be roughly 50% to 2X faster than @c std::sort for large tests (>=100kB).\n
@@ -363,7 +363,7 @@ Some performance plots of runtime vs. n and log(range) are provided:\n
 
 /*! \brief String sort algorithm using range, wraps using default of @c unsigned char.
 
-  (All variants fall back to @c std::sort if the data size is too small, < @c detail::min_sort_size).
+  (All variants fall back to @c boost::sort::pdqsort if the data size is too small, < @c detail::min_sort_size).
 
   \details @c string_sort is a fast templated in-place hybrid radix/comparison algorithm,
 which in testing tends to be roughly 50% to 2X faster than @c std::sort for large tests (>=100kB).\n
@@ -405,7 +405,7 @@ inline void reverse_string_sort(Range& range, Compare comp)
 
 /*! \brief String sort algorithm using random access iterators,  wraps using default of @c unsigned char.
 
-  (All variants fall back to @c std::sort if the data size is too small, < @c detail::min_sort_size).
+  (All variants fall back to @c boost::sort::pdqsort if the data size is too small, < @c detail::min_sort_size).
 
   \details @c string_sort is a fast templated in-place hybrid radix/comparison algorithm,
 which in testing tends to be roughly 50% to 2X faster than @c std::sort for large tests (>=100kB).\n
@@ -452,7 +452,7 @@ Some performance plots of runtime vs. n and log(range) are provided:\n
   {
     //Don't sort if it's too small to optimize
     if (last - first < detail::min_sort_size)
-      std::sort(first, last);
+      boost::sort::pdqsort(first, last);
     else {
       //skipping past empties, which allows us to get the character type
       //.empty() is not used so as not to require a user declaration of it
@@ -466,7 +466,7 @@ Some performance plots of runtime vs. n and log(range) are provided:\n
 
 /*! \brief String sort algorithm using range, wraps using default of @c unsigned char.
 
-  (All variants fall back to @c std::sort if the data size is too small, < @c detail::min_sort_size).
+  (All variants fall back to @c boost::sort::pdqsort if the data size is too small, < @c detail::min_sort_size).
 
   \details @c string_sort is a fast templated in-place hybrid radix/comparison algorithm,
 which in testing tends to be roughly 50% to 2X faster than @c std::sort for large tests (>=100kB).\n
@@ -511,7 +511,7 @@ inline void string_sort(Range& range, Get_char get_character, Get_length length)
 
 /*! \brief String sort algorithm using random access iterators,  wraps using default of @c unsigned char.
 
-  (All variants fall back to @c std::sort if the data size is too small, < @c detail::min_sort_size).
+  (All variants fall back to @c boost::sort::pdqsort if the data size is too small, < @c detail::min_sort_size).
 
   \details @c string_sort is a fast templated in-place hybrid radix/comparison algorithm,
 which in testing tends to be roughly 50% to 2X faster than @c std::sort for large tests (>=100kB).\n
@@ -560,7 +560,7 @@ Some performance plots of runtime vs. n and log(range) are provided:\n
   {
     //Don't sort if it's too small to optimize
     if (last - first < detail::min_sort_size)
-      std::sort(first, last, comp);
+      boost::sort::pdqsort(first, last, comp);
     else {
       //skipping past empties, which allows us to get the character type
       //.empty() is not used so as not to require a user declaration of it
@@ -575,7 +575,7 @@ Some performance plots of runtime vs. n and log(range) are provided:\n
 
 /*! \brief String sort algorithm using range, wraps using default of @c unsigned char.
 
-  (All variants fall back to @c std::sort if the data size is too small, < @c detail::min_sort_size).
+  (All variants fall back to @c boost::sort::pdqsort if the data size is too small, < @c detail::min_sort_size).
 
   \details @c string_sort is a fast templated in-place hybrid radix/comparison algorithm,
 which in testing tends to be roughly 50% to 2X faster than @c std::sort for large tests (>=100kB).\n
@@ -623,7 +623,7 @@ inline void string_sort(Range& range,
 
 /*! \brief Reverse String sort algorithm using random access iterators.
 
-  (All variants fall back to @c std::sort if the data size is too small, < @c detail::min_sort_size).
+  (All variants fall back to @c boost::sort::pdqsort if the data size is too small, < @c detail::min_sort_size).
 
  \details @c string_sort is a fast templated in-place hybrid radix/comparison algorithm,
 which in testing tends to be roughly 50% to 2X faster than @c std::sort for large tests (>=100kB).\n
@@ -672,7 +672,7 @@ Some performance plots of runtime vs. n and log(range) are provided:\n
   {
     //Don't sort if it's too small to optimize
     if (last - first < detail::min_sort_size)
-      std::sort(first, last, comp);
+      boost::sort::pdqsort(first, last, comp);
     else {
       //skipping past empties, which allows us to get the character type
       //.empty() is not used so as not to require a user declaration of it
@@ -689,7 +689,7 @@ Some performance plots of runtime vs. n and log(range) are provided:\n
 
 /*! \brief Reverse String sort algorithm using range.
 
-  (All variants fall back to @c std::sort if the data size is too small, < @c detail::min_sort_size).
+  (All variants fall back to @c boost::sort::pdqsort if the data size is too small, < @c detail::min_sort_size).
 
  \details @c string_sort is a fast templated in-place hybrid radix/comparison algorithm,
 which in testing tends to be roughly 50% to 2X faster than @c std::sort for large tests (>=100kB).\n


### PR DESCRIPTION
This provides a consistent modest speed boost, with no regressions in testing.