### PR TITLE
Guard uses of std::max and std::min

### DIFF
--- a/include/boost/sort/flat_stable_sort/flat_stable_sort.hpp
+++ b/include/boost/sort/flat_stable_sort/flat_stable_sort.hpp
@@ -179,7 +179,7 @@ bool flat_stable_sort <Iter_t, Compare, Power2>
     size_t nblock = size_t(itx_last - itx_first);
     range_it rng = get_group_range(*itx_first, nblock);
     size_t nelem = rng.size();
-    size_t min_process = std::max(BLOCK_SIZE, (nelem >> 3));
+    size_t min_process = (std::max)(BLOCK_SIZE, (nelem >> 3));
 
     size_t nsorted1 = bsc::number_stable_sorted_forward (rng.first, rng.last,
                                                          min_process, cmp);
@@ -221,7 +221,7 @@ bool flat_stable_sort <Iter_t, Compare, Power2>
     range_it rng = get_group_range(*itx_first, nblock);
 
     size_t nelem = rng.size();
-    size_t min_process = std::max(BLOCK_SIZE, (nelem >> 3));
+    size_t min_process = (std::max)(BLOCK_SIZE, (nelem >> 3));
 
     size_t nsorted2 = bsc::number_stable_sorted_backward(rng.first, rng.last,
                                                          min_process, cmp);


### PR DESCRIPTION
...in flat_stable_sort.hpp against the evils of windows.h.

This is necessary to make `test_block_indirect_sort` compile correctly, since it includes `boost/test` headers - which include windows.h so it can print pretty colors on the console - before `boost/sort/sort.hpp`.