### PR TITLE
Cease dependence on Serialization

### DIFF
--- a/include/boost/sort/spreadsort/detail/float_sort.hpp
+++ b/include/boost/sort/spreadsort/detail/float_sort.hpp
@@ -21,7 +21,6 @@ Scott McMurray
 #include <limits>
 #include <functional>
 #include <boost/static_assert.hpp>
-#include <boost/serialization/static_warning.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/sort/spreadsort/detail/constants.hpp>
 #include <boost/sort/spreadsort/detail/integer_sort.hpp>
@@ -735,7 +734,7 @@ namespace spreadsort {
       void >::type
     float_sort(RandomAccessIter first, RandomAccessIter last)
     {
-      BOOST_STATIC_WARNING(!(sizeof(boost::uint64_t) ==
+      BOOST_STATIC_ASSERT(!(sizeof(boost::uint64_t) ==
       sizeof(typename std::iterator_traits<RandomAccessIter>::value_type)
       || sizeof(boost::uint32_t) ==
       sizeof(typename std::iterator_traits<RandomAccessIter>::value_type))
@@ -778,7 +777,7 @@ namespace spreadsort {
     float_sort(RandomAccessIter first, RandomAccessIter last, Div_type,
                Right_shift rshift)
     {
-      BOOST_STATIC_WARNING(sizeof(boost::uintmax_t) >= sizeof(Div_type));
+      BOOST_STATIC_ASSERT(sizeof(boost::uintmax_t) >= sizeof(Div_type));
       boost::sort::pdqsort(first, last);
     }
 
@@ -820,7 +819,7 @@ namespace spreadsort {
     float_sort(RandomAccessIter first, RandomAccessIter last, Div_type,
                Right_shift rshift, Compare comp)
     {
-      BOOST_STATIC_WARNING(sizeof(boost::uintmax_t) >= sizeof(Div_type));
+      BOOST_STATIC_ASSERT(sizeof(boost::uintmax_t) >= sizeof(Div_type));
       boost::sort::pdqsort(first, last, comp);
     }
   }

--- a/include/boost/sort/spreadsort/detail/integer_sort.hpp
+++ b/include/boost/sort/spreadsort/detail/integer_sort.hpp
@@ -19,7 +19,6 @@ Phil Endecott and Frank Gennari
 #include <limits>
 #include <functional>
 #include <boost/static_assert.hpp>
-#include <boost/serialization/static_warning.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/sort/spreadsort/detail/constants.hpp>
 #include <boost/sort/spreadsort/detail/spreadsort_common.hpp>
@@ -392,7 +391,7 @@ namespace spreadsort {
     integer_sort(RandomAccessIter first, RandomAccessIter last, Div_type)
     {
       //Warning that we're using boost::sort::pdqsort, even though integer_sort was called
-      BOOST_STATIC_WARNING( sizeof(Div_type) <= sizeof(size_t) );
+      BOOST_STATIC_ASSERT( sizeof(Div_type) <= sizeof(size_t) );
       boost::sort::pdqsort(first, last);
     }
 
@@ -439,7 +438,7 @@ namespace spreadsort {
                 Right_shift shift, Compare comp)
     {
       //Warning that we're using boost::sort::pdqsort, even though integer_sort was called
-      BOOST_STATIC_WARNING( sizeof(Div_type) <= sizeof(size_t) );
+      BOOST_STATIC_ASSERT( sizeof(Div_type) <= sizeof(size_t) );
       boost::sort::pdqsort(first, last, comp);
     }
 
@@ -483,7 +482,7 @@ namespace spreadsort {
                 Right_shift shift)
     {
       //Warning that we're using boost::sort::pdqsort, even though integer_sort was called
-      BOOST_STATIC_WARNING( sizeof(Div_type) <= sizeof(size_t) );
+      BOOST_STATIC_ASSERT( sizeof(Div_type) <= sizeof(size_t) );
       boost::sort::pdqsort(first, last);
     }
   }

--- a/include/boost/sort/spreadsort/detail/spreadsort_common.hpp
+++ b/include/boost/sort/spreadsort/detail/spreadsort_common.hpp
@@ -21,7 +21,6 @@ Phil Endecott and Frank Gennari
 #include <limits>
 #include <functional>
 #include <boost/static_assert.hpp>
-#include <boost/serialization/static_warning.hpp>
 #include <boost/sort/pdqsort/pdqsort.hpp>
 #include <boost/sort/spreadsort/detail/constants.hpp>
 #include <boost/cstdint.hpp>

--- a/include/boost/sort/spreadsort/detail/string_sort.hpp
+++ b/include/boost/sort/spreadsort/detail/string_sort.hpp
@@ -20,7 +20,6 @@ Phil Endecott and Frank Gennari
 #include <limits>
 #include <functional>
 #include <boost/static_assert.hpp>
-#include <boost/serialization/static_warning.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/sort/spreadsort/detail/constants.hpp>
 #include <boost/sort/spreadsort/detail/spreadsort_common.hpp>
@@ -701,7 +700,7 @@ namespace spreadsort {
                 Unsigned_char_type)
     {
       //Warning that we're using boost::sort::pdqsort, even though string_sort was called
-      BOOST_STATIC_WARNING( sizeof(Unsigned_char_type) <= 2 );
+      BOOST_STATIC_ASSERT( sizeof(Unsigned_char_type) <= 2 );
       boost::sort::pdqsort(first, last);
     }
 
@@ -727,7 +726,7 @@ namespace spreadsort {
       typedef typename std::iterator_traits<RandomAccessIter>::value_type
         Data_type;
       //Warning that we're using boost::sort::pdqsort, even though string_sort was called
-      BOOST_STATIC_WARNING( sizeof(Unsigned_char_type) <= 2 );
+      BOOST_STATIC_ASSERT( sizeof(Unsigned_char_type) <= 2 );
       boost::sort::pdqsort(first, last, std::greater<Data_type>());
     }
 
@@ -753,7 +752,7 @@ namespace spreadsort {
                 Get_char get_character, Get_length length, Unsigned_char_type)
     {
       //Warning that we're using boost::sort::pdqsort, even though string_sort was called
-      BOOST_STATIC_WARNING( sizeof(Unsigned_char_type) <= 2 );
+      BOOST_STATIC_ASSERT( sizeof(Unsigned_char_type) <= 2 );
       boost::sort::pdqsort(first, last);
     }
 
@@ -781,7 +780,7 @@ namespace spreadsort {
         Get_char get_character, Get_length length, Compare comp, Unsigned_char_type)
     {
       //Warning that we're using boost::sort::pdqsort, even though string_sort was called
-      BOOST_STATIC_WARNING( sizeof(Unsigned_char_type) <= 2 );
+      BOOST_STATIC_ASSERT( sizeof(Unsigned_char_type) <= 2 );
       boost::sort::pdqsort(first, last, comp);
     }
 
@@ -808,7 +807,7 @@ namespace spreadsort {
         Get_char get_character, Get_length length, Compare comp, Unsigned_char_type)
     {
       //Warning that we're using boost::sort::pdqsort, even though string_sort was called
-      BOOST_STATIC_WARNING( sizeof(Unsigned_char_type) <= 2 );
+      BOOST_STATIC_ASSERT( sizeof(Unsigned_char_type) <= 2 );
       boost::sort::pdqsort(first, last, comp);
     }
   }


### PR DESCRIPTION
Replaced BOOST_STATIC_WARNING with BOOST_STATIC_ASSERT macro from
the StaticAssert library that had already been used.