### PR TITLE
flat_stable_sort: don't crash on empty iterator range

### DIFF
--- a/include/boost/sort/flat_stable_sort/flat_stable_sort.hpp
+++ b/include/boost/sort/flat_stable_sort/flat_stable_sort.hpp
@@ -264,6 +264,7 @@ template <class Iter_t, class Compare = bscu::compare_iter<Iter_t>,
 inline void flat_stable_sort (Iter_t first, Iter_t last,
                                  Compare cmp = Compare())
 {
+    if (last - first < 2) return;
     flat::flat_stable_sort<Iter_t, Compare, 6> (first, last, cmp);
 };
 
@@ -289,6 +290,7 @@ template <class Iter_t, class Compare = bscu::compare_iter<Iter_t>,
 inline void flat_stable_sort (Iter_t first, Iter_t last,
                                  Compare cmp = Compare())
 {
+    if (last - first < 2) return;
     flat::flat_stable_sort<Iter_t, Compare,
                            block_size_fss<sizeof(value_iter<Iter_t> )>::data>
         (first, last, cmp);

--- a/test/test_flat_stable_sort.cpp
+++ b/test/test_flat_stable_sort.cpp
@@ -21,9 +21,32 @@
 
 using namespace boost::sort;
 
+void test_small ( );
 void test1 ( );
 void test2 ( );
 void test3 ( );
+
+void test_small ( )
+{
+    std::vector< int > v, expected;
+    flat_stable_sort (v.begin ( ), v.end ( ));
+    BOOST_CHECK (v.empty ( ));
+
+    v.push_back (0);
+    expected = v;
+    flat_stable_sort (v.begin ( ), v.end ( ));
+    BOOST_CHECK (v == expected);
+
+    v.push_back (1);
+    expected = v;
+    flat_stable_sort (v.begin ( ), v.end ( ));
+    BOOST_CHECK (v == expected);
+
+    v.back ( ) = -1;
+    expected = { -1, 0 };
+    flat_stable_sort (v.begin ( ), v.end ( ));
+    BOOST_CHECK (v == expected);
+}
 
 //---------------- stability test -----------------------------------
 struct xk
@@ -133,6 +156,7 @@ void test3 (void)
 }
 int test_main (int, char *[])
 {
+    test_small ( );
     test1 ( );
     test2 ( );
     test3 ( );


### PR DESCRIPTION
**NOTE**: this change fixes the crash I encountered yesterday. But I do not understand the internals of `flat_stable_sort`. So the fix may be incomplete. Perhaps the proper if less efficient fix belongs to one of `flat_stable_sort`'s constructors or member functions.

**Details from the commit message**:
Without the added iterator distance checks, the new test crashes in the first call to flat_stable_sort.

Abbreviated output in Debug mode:
```
boost_sort: ...: Assertion `nblock > 0 and nblock < 5' failed.
```

The most interesting output line in Release mode (split into 3 lines):
```
unknown location(0): fatal error: in "test_main_caller( argc_ argv )":
  memory access violation at address: 0x00000000:
    no mapping at fault address
```