### PR TITLE
Guard another use of std::min from Windows.h corruption

### DIFF
--- a/include/boost/sort/pdqsort/pdqsort.hpp
+++ b/include/boost/sort/pdqsort/pdqsort.hpp
@@ -266,7 +266,7 @@ namespace pdqsort_detail {
                 }
 
                 // Swap elements and update block sizes and first/last boundaries.
-                size_t num = std::min(num_l, num_r);
+                size_t num = (std::min)(num_l, num_r);
                 swap_offsets(offsets_l_base, offsets_r_base,
                              offsets_l + start_l, offsets_r + start_r,
                              num, num_l == num_r);


### PR DESCRIPTION
The include order in test_block_indirect_sort will include Windows.h before sort.hpp on Windows, letting Windows.h corrupt unparenthesized uses of std::min.