### PR TITLE
Bugfix duplicate symbol error in time_measure.hpp

### DIFF
--- a/include/boost/sort/common/time_measure.hpp
+++ b/include/boost/sort/common/time_measure.hpp
@@ -39,7 +39,7 @@ double subtract_time  ( const time_point & t1, const time_point & t2 );
 /// @brief return the time system in a internal format ( steady_clock)
 /// @return time in steady_clock format
 //---------------------------------------------------------------------------
-time_point now ( ) {   return chrn::steady_clock::now( ); };
+inline time_point now ( ) {   return chrn::steady_clock::now( ); };
 //
 //---------------------------------------------------------------------------
 //  function : subtract_time
@@ -48,7 +48,7 @@ time_point now ( ) {   return chrn::steady_clock::now( ); };
 /// @param [in] t2 : second time in time_point format
 /// @return time in seconds of the difference of t1 - t2
 //---------------------------------------------------------------------------
-double subtract_time  ( const time_point & t1, const time_point & t2 )
+inline double subtract_time  ( const time_point & t1, const time_point & t2 )
 {   //------------------------ begin ---------------------------------
     chrn::duration<double> time_span =
                 chrn::duration_cast < chrn::duration < double > > ( t1 - t2 );


### PR DESCRIPTION
Free functions that are defined in header files must be qualified inline in order to avoid duplicate symbol errors at link time.  Bugfix two cases:
- boost::sort::common::now()
- boost::sort::common::subtract_time()