### PR TITLE
Apply `use std::swap` idiom for all calls to `std::swap`

### DIFF
--- a/include/boost/sort/block_indirect_sort/blk_detail/parallel_sort.hpp
+++ b/include/boost/sort/block_indirect_sort/blk_detail/parallel_sort.hpp
@@ -134,6 +134,7 @@ parallel_sort<Block_size, Iter_t, Compare>
 ::parallel_sort(backbone_t &bkbn, Iter_t first, Iter_t last)
  : bk(bkbn), counter(0)
 {
+    using std::swap;
     assert((last - first) >= 0);
     size_t nelem = size_t(last - first);
 
@@ -153,7 +154,7 @@ parallel_sort<Block_size, Iter_t, Compare>
         size_t nelem2 = nelem >> 1;
         Iter_t it1 = first, it2 = last - 1;
         for (size_t i = 0; i < nelem2; ++i)
-            std::swap(*(it1++), *(it2--));
+            swap(*(it1++), *(it2--));
         return;
     };
 
@@ -188,6 +189,7 @@ template<uint32_t Block_size, class Iter_t, class Compare>
 void parallel_sort<Block_size, Iter_t, Compare>
 ::divide_sort(Iter_t first, Iter_t last, uint32_t level)
 {
+    using std::swap;
     //------------------- check if sort -----------------------------------
     bool sorted = true;
     for (Iter_t it1 = first, it2 = first + 1;
@@ -211,14 +213,14 @@ void parallel_sort<Block_size, Iter_t, Compare>
 
     while (c_first < c_last)
     {
-        std::swap(*(c_first++), *(c_last--));
+        swap(*(c_first++), *(c_last--));
         while (bk.cmp(*c_first, val))
             ++c_first;
         while (bk.cmp(val, *c_last))
             --c_last;
     };
 
-    std::swap(*first, *c_last);
+    swap(*first, *c_last);
 
     // insert  the work of the second half in the stack of works
     function_divide_sort(c_first, last, level - 1, counter, bk.error);

--- a/include/boost/sort/block_indirect_sort/block_indirect_sort.hpp
+++ b/include/boost/sort/block_indirect_sort/block_indirect_sort.hpp
@@ -216,7 +216,8 @@ block_indirect_sort<Block_size, Group_size, Iter_t, Compare>
             Iter_t it1 = first, it2 = last - 1;
             for (size_t i = 0; i < nelem2; ++i)
             {
-                std::swap(*(it1++), *(it2--));
+		using std::swap;
+                swap(*(it1++), *(it2--));
             };
             return;
         };

--- a/include/boost/sort/common/merge_four.hpp
+++ b/include/boost/sort/common/merge_four.hpp
@@ -76,6 +76,7 @@ range<Iter1_t> full_merge4(const range<Iter1_t> &rdest,
                            range<Iter2_t> vrange_input[4],
                            uint32_t nrange_input, Compare comp)
 {
+    using std::swap;
     typedef range<Iter1_t> range1_t;
     typedef util::value_iter<Iter1_t> type1;
     typedef util::value_iter<Iter2_t> type2;
@@ -120,28 +121,28 @@ range<Iter1_t> full_merge4(const range<Iter1_t> &rdest,
     if (less_range(vrange_input[pos[1]].first, pos[1],
                     vrange_input[pos[0]].first, pos[0], comp))
     {
-        std::swap(pos[0], pos[1]);
+        swap(pos[0], pos[1]);
     };
     if (npos == 4 and less_range(vrange_input[pos[3]].first, pos[3],
                                  vrange_input[pos[2]].first, pos[2], comp))
     {
-        std::swap(pos[3], pos[2]);
+        swap(pos[3], pos[2]);
     };
     if (less_range (vrange_input[pos[2]].first, pos[2],
                     vrange_input[pos[0]].first, pos[0], comp))
     {
-        std::swap(pos[0], pos[2]);
+        swap(pos[0], pos[2]);
     };
     if (npos == 4
                     and less_range (vrange_input[pos[3]].first, pos[3],
                                     vrange_input[pos[1]].first, pos[1], comp))
     {
-        std::swap(pos[1], pos[3]);
+        swap(pos[1], pos[3]);
     };
     if (less_range (vrange_input[pos[2]].first, pos[2],
                     vrange_input[pos[1]].first, pos[1], comp))
     {
-        std::swap(pos[1], pos[2]);
+        swap(pos[1], pos[2]);
     };
 
     Iter1_t it_dest = rdest.first;
@@ -160,18 +161,18 @@ range<Iter1_t> full_merge4(const range<Iter1_t> &rdest,
             if (less_range(vrange_input[pos[1]].first, pos[1],
                             vrange_input[pos[0]].first, pos[0], comp))
             {
-                std::swap(pos[0], pos[1]);
+                swap(pos[0], pos[1]);
                 if (less_range(vrange_input[pos[2]].first, pos[2],
                                 vrange_input[pos[1]].first, pos[1], comp))
                 {
-                    std::swap(pos[1], pos[2]);
+                    swap(pos[1], pos[2]);
                     if (npos == 4
                                     and less_range(vrange_input[pos[3]].first,
                                                     pos[3],
                                                     vrange_input[pos[2]].first,
                                                     pos[2], comp))
                     {
-                        std::swap(pos[2], pos[3]);
+                        swap(pos[2], pos[3]);
                     };
                 };
             };
@@ -208,6 +209,7 @@ range<Value_t *> uninit_full_merge4(const range<Value_t *> &dest,
                                     range<Iter_t> vrange_input[4],
                                     uint32_t nrange_input, Compare comp)
 {
+    using std::swap;
     typedef util::value_iter<Iter_t> type1;
     static_assert (std::is_same< type1, Value_t >::value,
                     "Incompatible iterators\n");
@@ -248,27 +250,27 @@ range<Value_t *> uninit_full_merge4(const range<Value_t *> &dest,
     if (less_range(vrange_input[pos[1]].first, pos[1],
                     vrange_input[pos[0]].first, pos[0], comp))
     {
-        std::swap(pos[0], pos[1]);
+        swap(pos[0], pos[1]);
     };
     if (npos == 4  and less_range(vrange_input[pos[3]].first, pos[3],
                                   vrange_input[pos[2]].first, pos[2], comp))
     {
-        std::swap(pos[3], pos[2]);
+        swap(pos[3], pos[2]);
     };
     if (less_range(vrange_input[pos[2]].first, pos[2],
                     vrange_input[pos[0]].first, pos[0], comp))
     {
-        std::swap(pos[0], pos[2]);
+        swap(pos[0], pos[2]);
     };
     if (npos == 4 and less_range(vrange_input[pos[3]].first, pos[3],
                                  vrange_input[pos[1]].first, pos[1], comp))
     {
-        std::swap(pos[1], pos[3]);
+        swap(pos[1], pos[3]);
     };
     if (less_range(vrange_input[pos[2]].first, pos[2],
                     vrange_input[pos[1]].first, pos[1], comp))
     {
-        std::swap(pos[1], pos[2]);
+        swap(pos[1], pos[2]);
     };
 
     Value_t *it_dest = dest.first;
@@ -288,17 +290,17 @@ range<Value_t *> uninit_full_merge4(const range<Value_t *> &dest,
             if (less_range (vrange_input[pos[1]].first, pos[1],
                             vrange_input[pos[0]].first, pos[0], comp))
             {
-                std::swap(pos[0], pos[1]);
+                swap(pos[0], pos[1]);
                 if (less_range (vrange_input[pos[2]].first, pos[2],
                                 vrange_input[pos[1]].first, pos[1], comp))
                 {
-                    std::swap(pos[1], pos[2]);
+                    swap(pos[1], pos[2]);
                     if (npos == 4 and less_range(vrange_input[pos[3]].first,
                                                  pos[3],
                                                  vrange_input[pos[2]].first,
                                                  pos[2], comp))
                     {
-                        std::swap(pos[2], pos[3]);
+                        swap(pos[2], pos[3]);
                     };
                 };
             };

--- a/include/boost/sort/common/pivot.hpp
+++ b/include/boost/sort/common/pivot.hpp
@@ -43,10 +43,11 @@ namespace common
 template < typename Iter_t, typename Compare >
 inline Iter_t mid3 (Iter_t iter_1, Iter_t iter_2, Iter_t iter_3, Compare comp)
 {
-	if (comp (*iter_2, *iter_1)) std::swap ( *iter_2, *iter_1);
+    using std::swap;
+	if (comp (*iter_2, *iter_1)) swap ( *iter_2, *iter_1);
 	if (comp (*iter_3, *iter_2))
-	{	std::swap ( *iter_3, *iter_2);
-		if (comp (*iter_2, *iter_1)) std::swap ( *iter_2, *iter_1);
+	{	swap ( *iter_3, *iter_2);
+		if (comp (*iter_2, *iter_1)) swap ( *iter_2, *iter_1);
 	};
 	return iter_2;
 };
@@ -64,9 +65,10 @@ inline Iter_t mid3 (Iter_t iter_1, Iter_t iter_2, Iter_t iter_3, Compare comp)
 template < class Iter_t, class Compare >
 inline void pivot3 (Iter_t first, Iter_t last, Compare comp)
 {
+    using std::swap;
     auto N2 = (last - first) >> 1;
     Iter_t it_val = mid3 (first + 1, first + N2, last - 1, comp);
-    std::swap (*first, *it_val);
+    swap (*first, *it_val);
 };
 
 //
@@ -110,11 +112,12 @@ inline Iter_t mid9 (Iter_t iter_1, Iter_t iter_2, Iter_t iter_3, Iter_t iter_4,
 template < class Iter_t, class Compare >
 inline void pivot9 (Iter_t first, Iter_t last, Compare comp)
 {
+    using std::swap;
     size_t cupo = (last - first) >> 3;
     Iter_t itaux = mid9 (first + 1, first + cupo, first + 2 * cupo,
                          first + 3 * cupo, first + 4 * cupo, first + 5 * cupo,
                          first + 6 * cupo, first + 7 * cupo, last - 1, comp);
-    std::swap (*first, *itaux);
+    swap (*first, *itaux);
 };
 //****************************************************************************
 };//    End namespace common

--- a/include/boost/sort/common/rearrange.hpp
+++ b/include/boost/sort/common/rearrange.hpp
@@ -92,8 +92,9 @@ void rearrange(Iter_data global_first, Iter_index itx_first,
 
         while ((pos_src = pos(itx_src)) != pos_ini)
         {
+	    using std::swap;
             data[pos_dest] = std::move(data[pos_src]);
-            std::swap(itx_src, index[pos_src]);
+            swap(itx_src, index[pos_src]);
             pos_dest = pos_src;
         };
 

--- a/include/boost/sort/parallel_stable_sort/parallel_stable_sort.hpp
+++ b/include/boost/sort/parallel_stable_sort/parallel_stable_sort.hpp
@@ -150,10 +150,11 @@ parallel_stable_sort <Iter_t, Compare>
          it2 != last and (sw = comp(*it2, *it1)); it1 = it2++);
     if (sw)
     {
+	using std::swap;
         size_t nelem2 = nelem >> 1;
         Iter_t it1 = first, it2 = last - 1;
         for (size_t i = 0; i < nelem2; ++i)
-            std::swap(*(it1++), *(it2--));
+            swap(*(it1++), *(it2--));
         return;
     };
 

--- a/include/boost/sort/sample_sort/sample_sort.hpp
+++ b/include/boost/sort/sample_sort/sample_sort.hpp
@@ -273,10 +273,11 @@ sample_sort<Iter_t, Compare>
                     it2 != last and (sw = comp(*it2, *it1)); it1 = it2++);
     if (sw)
     {
+	using std::swap;
         size_t nelem2 = nelem >> 1;
         Iter_t it1 = first, it2 = last - 1;
         for (size_t i = 0; i < nelem2; ++i)
-            std::swap(*(it1++), *(it2--));
+            swap(*(it1++), *(it2--));
         return;
     };
 

--- a/include/boost/sort/spinsort/spinsort.hpp
+++ b/include/boost/sort/spinsort/spinsort.hpp
@@ -209,8 +209,10 @@ static bool check_stable_sort(const range<Iter1_t> &rng_data,
     size_t nreverse = it2 - rng_data.first;
     Iter1_t alpha(rng_data.first), beta(it2 - 1), mid(
                     rng_data.first + (nreverse >> 1));
-    while (alpha != mid)
-        std::swap(*(alpha++), *(beta--));
+    while (alpha != mid) {
+	using std::swap;
+        swap(*(alpha++), *(beta--));
+    }
 
     // insert the elements between it1 and last
     if (it2 != rng_data.last)
@@ -470,10 +472,11 @@ spinsort <Iter_t, Compare>
          it2 != last and (sw = comp(*it2, *it1)); it1 = it2++);
     if (sw)
     {
+	using std::swap;
         size_t nelem2 = nelem >> 1;
         Iter_t it1 = first, it2 = last - 1;
         for (size_t i = 0; i < nelem2; ++i)
-            std::swap(*(it1++), *(it2--));
+            swap(*(it1++), *(it2--));
         return;
     };
 


### PR DESCRIPTION
These changes address issue #72.

I replaced all explicit calls to `std::swap` with,
```c++
using std::swap;
swap(a, b);
```
I tried to minimize the number of code changes while keeping the `using std::swap` directives close to the calls to `swap`. They are often on consecutive lines, but in functions with several calls to `swap`, I placed a single using directive at the start of the nearest block. This was a judgment call.

This brings the code up to date with `C++20` which does not allow adding template function specializations to the `std` namespace while maintaining compatibility with existing code.

There is the possibility that a lookup that previously found `swap` for a user-defined type in `std` will now find a different version in the type's namespace using ADL. In theory, this will only happen if you have defined two different `swap` implementations and put one in `std` and one in the type's namespace.

All the tests passed without error:
```
Running 1 test case...

*** No errors detected
Running 1 test case...

*** No errors detected
Running 1 test case...

*** No errors detected
Running 1 test case...

*** No errors detected
Running 1 test case...

*** No errors detected
Running 1 test case...

*** No errors detected
Running 1 test case...
1, 2, 3, 4, 5,
8, 6, 10, 4, 2, 3, 5, 7, 9, 11, 13, 15, 17, 19,
8, 6, 10, 4, 2, 13, 15, 17, 19, 21, 23, 35, 27, 29,
3, 5, 7, 9, 11, 13, 15, 17, 19, 28, 26, 30, 24, 22,

*** No errors detected
Running 1 test case...

*** No errors detected
Running 1 test case...

*** No errors detected
Running 1 test case...

*** No errors detected
Running 1 test case...
1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 23, 25, 27, 29, 31, 3\
3, 35, 37, 39, 41, 43, 45, 47, 49, 51, 53, 55, 57, 59,
1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 23, 25, 27, 29, 31, 3\
3, 35, 37, 39, 41, 43, 45, 47, 49, 51, 53, 55, 57, 59,

*** No errors detected
```
