### PR TITLE
Remove unnecessary semicolons for gcc --pedantic mode

### DIFF
--- a/include/boost/sort/block_indirect_sort/blk_detail/backbone.hpp
+++ b/include/boost/sort/block_indirect_sort/blk_detail/backbone.hpp
@@ -107,7 +107,7 @@ struct backbone
     block_t get_block (size_t pos) const
     {
         return block_t (global_range.first + (pos * Block_size));
-    };
+    }
     //-------------------------------------------------------------------------
     //  function : get_range
     /// @brief obtain the range in the position pos
@@ -120,7 +120,7 @@ struct backbone
         Iter_t it2 =
             (pos == (nblock - 1)) ? global_range.last : it1 + Block_size;
         return range_it (it1, it2);
-    };
+    }
     //-------------------------------------------------------------------------
     //  function : get_range_buf
     /// @brief obtain the auxiliary buffer of the thread
@@ -128,7 +128,7 @@ struct backbone
     range_buf get_range_buf ( ) const
     {
         return range_buf (buf, buf + Block_size);
-    };
+    }
 
     //-------------------------------------------------------------------------
     //  function : exec
@@ -144,7 +144,7 @@ struct backbone
     {
         buf = ptr_buf;
         exec (counter);
-    };
+    }
 
     void exec (atomic_t &counter);
 
@@ -192,7 +192,7 @@ backbone< Block_size, Iter_t, Compare >
     range_tail.first =
         (ntail == 0) ? last : (first + ((nblock - 1) * Block_size));
     range_tail.last = last;
-};
+}
 //
 //-------------------------------------------------------------------------
 //  function : exec
@@ -208,12 +208,12 @@ void backbone< Block_size, Iter_t, Compare >::exec (atomic_t &counter)
     {
         if (works.pop_move_back (func_exec)) func_exec ( );
         else std::this_thread::yield ( );
-    };
-};
+    }
+}
 //
 //****************************************************************************
-}; //    End namespace blk_detail
-}; //    End namespace sort
-}; //    End namespace boost
+} //    End namespace blk_detail
+} //    End namespace sort
+} //    End namespace boost
 //****************************************************************************
 #endif

--- a/include/boost/sort/block_indirect_sort/blk_detail/block.hpp
+++ b/include/boost/sort/block_indirect_sort/blk_detail/block.hpp
@@ -44,7 +44,7 @@ class block_pos
 
   public:
     //----------------------------- FUNCTIONS ------------------------------
-    block_pos (void) : num (0){};
+    block_pos (void) : num (0){}
     //
     //-------------------------------------------------------------------------
     //  function : block_pos
@@ -55,35 +55,35 @@ class block_pos
     block_pos (size_t position, bool side = false)
     {
         num = (position << 1) + ((side) ? 1 : 0);
-    };
+    }
     //
     //-------------------------------------------------------------------------
     //  function : pos
     /// @brief obtain the position stored inside the block_pos
     /// @return position
     //-------------------------------------------------------------------------
-    size_t pos (void) const { return (num >> 1); };
+    size_t pos (void) const { return (num >> 1); }
     //
     //-------------------------------------------------------------------------
     //  function : pos
     /// @brief store a position inside the block_pos
     /// @param position : value to store
     //-------------------------------------------------------------------------
-    void set_pos (size_t position) { num = (position << 1) + (num & 1); };
+    void set_pos (size_t position) { num = (position << 1) + (num & 1); }
     //
     //-------------------------------------------------------------------------
     //  function : side
     /// @brief obtain the side stored inside the block_pos
     /// @return bool value
     //-------------------------------------------------------------------------
-    bool side (void) const { return ((num & 1) != 0); };
+    bool side (void) const { return ((num & 1) != 0); }
     //
     //-------------------------------------------------------------------------
     //  function : side
     /// @brief store a bool value the block_pos
     /// @param sd : bool value to store
     //-------------------------------------------------------------------------
-    void set_side (bool sd) { num = (num & ~1) + ((sd) ? 1 : 0); };
+    void set_side (bool sd) { num = (num & ~1) + ((sd) ? 1 : 0); }
 }; // end struct block_pos
 
 //
@@ -105,7 +105,7 @@ struct block
     /// @brief constructor from an iterator to the first element of the block
     /// @param it : iterator to the first element of the block
     //-------------------------------------------------------------------------
-    block (Iter_t it) : first (it){};
+    block (Iter_t it) : first (it){}
 
     //-------------------------------------------------------------------------
     //  function : get_range
@@ -115,7 +115,7 @@ struct block
     range< Iter_t > get_range (void)
     {
         return range_it (first, first + Block_size);
-    };
+    }
 
 }; // end struct block
 
@@ -133,7 +133,7 @@ bool compare_block (block< Block_size, Iter_t > block1,
                     Compare cmp = Compare ( ))
 {
     return cmp (*block1.first, *block2.first);
-};
+}
 //
 ///---------------------------------------------------------------------------
 /// @struct compare_block_pos
@@ -155,7 +155,7 @@ struct compare_block_pos
     /// @param cmp : comparison operator
     //-------------------------------------------------------------------------
     compare_block_pos (Iter_t g_first, Compare cmp)
-        : global_first (g_first), comp (cmp){};
+        : global_first (g_first), comp (cmp){}
     //
     //-------------------------------------------------------------------------
     //  function : operator ()
@@ -168,14 +168,14 @@ struct compare_block_pos
     {
         return comp (*(global_first + (block_pos1.pos ( ) * Block_size)),
                      *(global_first + (block_pos2.pos ( ) * Block_size)));
-    };
+    }
 
 }; // end struct compare_block_pos
 
 //****************************************************************************
-}; //    End namespace blk_detail
-}; //    End namespace sort
-}; //    End namespace boost
+} //    End namespace blk_detail
+} //    End namespace sort
+} //    End namespace boost
 //****************************************************************************
 //
 #endif

--- a/include/boost/sort/block_indirect_sort/blk_detail/merge_blocks.hpp
+++ b/include/boost/sort/block_indirect_sort/blk_detail/merge_blocks.hpp
@@ -108,7 +108,7 @@ struct merge_blocks
                 catch (std::bad_alloc &)
                 {
                     error = true;
-                };
+                }
             }
             bscu::atomic_sub (counter, 1);
         };
@@ -143,7 +143,7 @@ struct merge_blocks
                 catch (std::bad_alloc &)
                 {
                     error = true;
-                };
+                }
             }
             bscu::atomic_sub (counter, 1);
         };
@@ -195,12 +195,12 @@ merge_blocks<Block_size, Group_size, Iter_t, Compare>
     for (size_t i = pos_index1; i < pos_index2; ++i)
     {
         vpos1.emplace_back(bk.index[i].pos(), true);
-    };
+    }
 
     for (size_t i = pos_index2; i < pos_index3; ++i)
     {
         vpos2.emplace_back(bk.index[i].pos(), false);
-    };
+    }
     //-------------------------------------------------------------------
     //  tail process
     //-------------------------------------------------------------------
@@ -210,7 +210,7 @@ merge_blocks<Block_size, Group_size, Iter_t, Compare>
         tail_process(vpos1, vpos2);
         nblock1 = vpos1.size();
         nblock2 = vpos2.size();
-    };
+    }
 
     compare_block_pos_t cmp_blk(bk.global_range.first, bk.cmp);
     if (bk.error) return;
@@ -256,9 +256,9 @@ void merge_blocks<Block_size, Group_size, Iter_t, Compare>
             {
                 vblkpos2.emplace_back(posback1, false);
                 vblkpos1.pop_back();
-            };
-        };
-    };
+            }
+        }
+    }
 }
 
 //
@@ -278,7 +278,7 @@ void merge_blocks<Block_size, Group_size, Iter_t, Compare>
     {
         merge_range_pos(rng_input);
         return;
-    };
+    }
 
     atomic_t counter(0);
     size_t npart = (rng_input.size() + Group_size - 1) / Group_size;
@@ -294,7 +294,7 @@ void merge_blocks<Block_size, Group_size, Iter_t, Compare>
                         and bk.index[pos - 1].side() == bk.index[pos].side())
         {
             ++pos;
-        };
+        }
         if (pos < pos_last)
         {
             merge_uncontiguous(bk.get_range(bk.index[pos - 1].pos()),
@@ -306,9 +306,9 @@ void merge_blocks<Block_size, Group_size, Iter_t, Compare>
         {
             range_pos rng_aux(pos_ini, pos);
             function_merge_range_pos(rng_aux, counter, bk.error);
-        };
+        }
         pos_ini = pos;
-    };
+    }
     bk.exec(counter); // wait until finish all the ranges
 }
 
@@ -337,7 +337,7 @@ void merge_blocks<Block_size, Group_size, Iter_t, Compare>
         bsc::merge_flow(rng_prev, rbuf, rng_posx, bk.cmp);
         rng_prev = rng_posx;
 
-    };
+    }
     move_forward(rng_posx, rbuf);
 }
 //
@@ -384,7 +384,7 @@ void merge_blocks<Block_size, Group_size, Iter_t, Compare>
             side_posx = bp_posx.side();
             mergeable = (side_max != side_posx
                             and is_mergeable(rng_max, rng_posx, bk.cmp));
-        };
+        }
         if (bk.error) return;
         if (final or not mergeable)
         {
@@ -398,14 +398,14 @@ void merge_blocks<Block_size, Group_size, Iter_t, Compare>
                 else
                 {
                     function_merge_range_pos(rp_final, counter, bk.error);
-                };
-            };
+                }
+            }
             posx_ini = posx;
             if (not final)
             {
                 rng_max = rng_posx;
                 side_max = side_posx;
-            };
+            }
         }
         else
         {
@@ -413,16 +413,16 @@ void merge_blocks<Block_size, Group_size, Iter_t, Compare>
             {
                 rng_max = rng_posx;
                 side_max = side_posx;
-            };
-        };
-    };
+            }
+        }
+    }
     bk.exec(counter);
 }
 //
 //****************************************************************************
-}; //    End namespace blk_detail
-}; //    End namespace sort
-}; //    End namespace boost
+} //    End namespace blk_detail
+} //    End namespace sort
+} //    End namespace boost
 //****************************************************************************
 //
 #endif

--- a/include/boost/sort/block_indirect_sort/blk_detail/move_blocks.hpp
+++ b/include/boost/sort/block_indirect_sort/blk_detail/move_blocks.hpp
@@ -203,7 +203,7 @@ move_blocks<Block_size, Group_size, Iter_t, Compare>
     }
     bk.exec(counter);
 }
-;
+
 //
 //-------------------------------------------------------------------------
 //  function : move_sequence

--- a/include/boost/sort/block_indirect_sort/blk_detail/move_blocks.hpp
+++ b/include/boost/sort/block_indirect_sort/blk_detail/move_blocks.hpp
@@ -95,7 +95,7 @@ struct move_blocks
                 catch (std::bad_alloc &)
                 {
                     error = true;
-                };
+                }
             }
             bscu::atomic_sub (counter, 1);
         };
@@ -130,13 +130,13 @@ struct move_blocks
                 catch (std::bad_alloc &)
                 {
                     error = true;
-                };
+                }
             }
             bscu::atomic_sub (counter, 1);
         };
         bk.works.emplace_back(f1);
     }
-    ;
+
 //---------------------------------------------------------------------------
 }; // end of struct move_blocks
 //---------------------------------------------------------------------------
@@ -172,7 +172,7 @@ move_blocks<Block_size, Group_size, Iter_t, Compare>
                         and bk.index[pos_index_ini].pos() == pos_index_ini)
         {
             ++pos_index_ini;
-        };
+        }
 
         if (pos_index_ini == bk.index.size()) break;
 
@@ -187,7 +187,7 @@ move_blocks<Block_size, Group_size, Iter_t, Compare>
 
             bk.index[pos_index_dest].set_pos(pos_index_dest);
             pos_index_dest = pos_index_src;
-        };
+        }
 
         bk.index[pos_index_dest].set_pos(pos_index_dest);
         vsequence.push_back(sequence);
@@ -199,8 +199,8 @@ move_blocks<Block_size, Group_size, Iter_t, Compare>
         else
         {
             function_move_long_sequence(vsequence.back(), counter, bk.error);
-        };
-    };
+        }
+    }
     bk.exec(counter);
 }
 ;
@@ -228,9 +228,9 @@ void move_blocks<Block_size, Group_size, Iter_t, Compare>
         range_it range1(range2);
         range2 = bk.get_range(pos_range2);
         move_forward(range1, range2);
-    };
+    }
     move_forward(range2, rbuf);
-};
+}
 //
 //-------------------------------------------------------------------------
 //  function : move_long_sequence
@@ -264,7 +264,7 @@ void move_blocks<Block_size, Group_size, Iter_t, Compare>
         sequence.assign(it_pos, it_pos + size_part);
         index_seq.emplace_back(*(it_pos + size_part - 1));
         function_move_sequence(sequence, son_counter, bk.error);
-    };
+    }
 
     sequence.assign(it_pos, init_sequence.end());
     index_seq.emplace_back(init_sequence.back());
@@ -277,9 +277,9 @@ void move_blocks<Block_size, Group_size, Iter_t, Compare>
 
 //
 //****************************************************************************
-}; //    End namespace blk_detail
-}; //    End namespace sort
-}; //    End namespace boost
+} //    End namespace blk_detail
+} //    End namespace sort
+} //    End namespace boost
 //****************************************************************************
 //
 #endif

--- a/include/boost/sort/block_indirect_sort/blk_detail/parallel_sort.hpp
+++ b/include/boost/sort/block_indirect_sort/blk_detail/parallel_sort.hpp
@@ -103,12 +103,12 @@ struct parallel_sort
                 catch (std::bad_alloc &)
                 {
                     error = true;
-                };
-            };
+                }
+            }
             bscu::atomic_sub (counter, 1);
         };
         bk.works.emplace_back(f1);
-    };
+    }
 
 //--------------------------------------------------------------------------
 };// end struct parallel_sort
@@ -156,7 +156,7 @@ parallel_sort<Block_size, Iter_t, Compare>
         for (size_t i = 0; i < nelem2; ++i)
             swap(*(it1++), *(it2--));
         return;
-    };
+    }
 
     //-------------------max_per_thread ---------------------------
     uint32_t nbits_size = (nbits64(sizeof(value_t))) >> 1;
@@ -170,12 +170,12 @@ parallel_sort<Block_size, Iter_t, Compare>
     {
         pdqsort(first, last, bk.cmp);
         return;
-    };
+    }
     if (not bk.error) divide_sort(first, last, level);
 
     // wait until all the parts are finished
     bk.exec(counter);
-};
+}
 
 //------------------------------------------------------------------------
 //  function : divide_sort
@@ -201,7 +201,7 @@ void parallel_sort<Block_size, Iter_t, Compare>
     if (level == 0 or nelem < (max_per_thread))
     {
         return pdqsort(first, last, bk.cmp);
-    };
+    }
 
     //-------------------- pivoting  ----------------------------------
     pivot9(first, last, bk.cmp);
@@ -218,7 +218,7 @@ void parallel_sort<Block_size, Iter_t, Compare>
             ++c_first;
         while (bk.cmp(val, *c_last))
             --c_last;
-    };
+    }
 
     swap(*first, *c_last);
 
@@ -228,12 +228,12 @@ void parallel_sort<Block_size, Iter_t, Compare>
 
     // The first half is done by the same thread
     function_divide_sort(first, c_last, level - 1, counter, bk.error);
-};
+}
 //
 //****************************************************************************
-};//    End namespace blk_detail
-};//    End namespace sort
-};//    End namespace boost
+} //    End namespace blk_detail
+} //    End namespace sort
+} //    End namespace boost
 //****************************************************************************
 //
 #endif

--- a/include/boost/sort/block_indirect_sort/block_indirect_sort.hpp
+++ b/include/boost/sort/block_indirect_sort/block_indirect_sort.hpp
@@ -144,10 +144,10 @@ struct block_indirect_sort
             {
                 destroy(rglobal_buf);
                 construct = false;
-            };
+            }
             std::free (ptr);
             ptr = nullptr;
-        };
+        }
     }
     //
     //------------------------------------------------------------------------
@@ -218,9 +218,9 @@ block_indirect_sort<Block_size, Group_size, Iter_t, Compare>
             {
 		using std::swap;
                 swap(*(it1++), *(it2--));
-            };
+            }
             return;
-        };
+        }
 
         //---------------- check if only single thread -----------------------
         size_t nthreadmax = nelem / (Block_size * Group_size) + 1;
@@ -235,7 +235,7 @@ block_indirect_sort<Block_size, Group_size, Iter_t, Compare>
             //intro_sort (first, last, bk.cmp);
             pdqsort(first, last, bk.cmp);
             return;
-        };
+        }
 
         //----------- creation of the temporary buffer --------------------
         ptr = reinterpret_cast <value_t*>
@@ -244,7 +244,7 @@ block_indirect_sort<Block_size, Group_size, Iter_t, Compare>
         {
             bk.error = true;
             throw std::bad_alloc();
-        };
+        }
 
         rglobal_buf = range_buf(ptr, ptr + (Block_size * nthread));
         initialize(rglobal_buf, *first);
@@ -255,7 +255,7 @@ block_indirect_sort<Block_size, Group_size, Iter_t, Compare>
         for (uint32_t i = 0; i < nthread; ++i)
         {
             vbuf[i] = ptr + (i * Block_size);
-        };
+        }
 
         // Insert the first work in the stack
         bscu::atomic_write(counter, 1);
@@ -280,7 +280,7 @@ block_indirect_sort<Block_size, Group_size, Iter_t, Compare>
             auto f1 = [&vbuf,i, this]( )
             {   bk.exec (vbuf[i], this->counter);};
             vfuture[i] = std::async(std::launch::async, f1);
-        };
+        }
         for (uint32_t i = 0; i < nthread; ++i)
             vfuture[i].get();
         if (bk.error) throw std::bad_alloc();
@@ -290,7 +290,7 @@ block_indirect_sort<Block_size, Group_size, Iter_t, Compare>
         destroy_all();
         throw;
     }
-};
+}
 //
 //-----------------------------------------------------------------------------
 //  function : split_rage
@@ -317,7 +317,7 @@ void block_indirect_sort<Block_size, Group_size, Iter_t, Compare>
     {
         pdqsort(first, last, bk.cmp);
         return;
-    };
+    }
 
     size_t pos_index_mid = pos_index1 + (nblock >> 1);
     atomic_t son_counter(1);
@@ -349,11 +349,11 @@ void block_indirect_sort<Block_size, Group_size, Iter_t, Compare>
         bk.works.emplace_back(f1);
         if (bk.error) return;
         parallel_sort_t(bk, first, mid);
-    };
+    }
     bk.exec(son_counter);
     if (bk.error) return;
     merge_blocks_t(bk, pos_index1, pos_index_mid, pos_index2);
-};
+}
 
 //
 //-----------------------------------------------------------------------------
@@ -375,8 +375,8 @@ void block_indirect_sort<Block_size, Group_size, Iter_t, Compare>
         split_range(0, bk.nblock, level_thread - 1);
         if (bk.error) return;
         move_blocks_t k(bk);
-    };
-};
+    }
+}
 
 ///---------------------------------------------------------------------------
 //  function block_indirect_sort_call
@@ -390,7 +390,7 @@ inline void block_indirect_sort_call(Iter_t first, Iter_t last, Compare cmp,
                 uint32_t nthr)
 {
     block_indirect_sort<128, 128, Iter_t, Compare>(first, last, cmp, nthr);
-};
+}
 
 template<size_t Size>
 struct block_size
@@ -415,11 +415,11 @@ inline void block_indirect_sort_call (Iter_t first, Iter_t last, Compare cmp,
 {
     block_indirect_sort<block_size<sizeof (value_iter<Iter_t> )>::data, 64,
                         Iter_t, Compare> (first, last, cmp, nthr);
-};
+}
 
 //
 //****************************************************************************
-}; //    End namespace blk_detail
+} //    End namespace blk_detail
 //****************************************************************************
 //
 namespace bscu = boost::sort::common::util;
@@ -503,8 +503,8 @@ void block_indirect_sort (Iter_t first, Iter_t last, Compare comp,
 }
 //
 //****************************************************************************
-}; //    End namespace sort
-}; //    End namespace boost
+} //    End namespace sort
+} //    End namespace boost
 //****************************************************************************
 //
 #endif

--- a/include/boost/sort/common/indirect.hpp
+++ b/include/boost/sort/common/indirect.hpp
@@ -79,7 +79,8 @@ void create_index(Iter_t first, Iter_t last, std::vector<Iter_t> &index)
     index.clear();
     index.reserve(nelem);
     for (; first != last; ++first) index.push_back(first);
-};
+}
+
 //
 //-----------------------------------------------------------------------------
 //  function : sort_index
@@ -106,7 +107,7 @@ void sort_index(Iter_t global_first, std::vector<Iter_t> &index)
                (size_t(index[pos_in_vector] - global_first)) == pos_in_vector)
         {
             ++pos_in_vector;
-        };
+        }
 
         if (pos_in_vector == nelem) return;
         pos_dest = pos_src = pos_in_vector;
@@ -121,13 +122,13 @@ void sort_index(Iter_t global_first, std::vector<Iter_t> &index)
             *it_dest = std::move(*it_src);
             it_dest = it_src;
             pos_dest = pos_src;
-        };
+        }
 
         *it_dest = std::move(Aux);
         index[pos_dest] = it_dest;
         ++pos_in_vector;
-    };
-};
+    }
+}
 
 template<class func, class Iter_t, class Compare = util::compare_iter<Iter_t> >
 void indirect_sort(func method, Iter_t first, Iter_t last, Compare comp)
@@ -141,13 +142,13 @@ void indirect_sort(func method, Iter_t first, Iter_t last, Compare comp)
     less_ptr_no_null<Iter_t, Compare> index_comp(comp);
     method(index.begin(), index.end(), index_comp);
     sort_index(first, index);
-};
+}
 
 //
 //****************************************************************************
-};//    End namespace common
-};//    End namespace sort
-};//    End namespace boost
+}//    End namespace common
+}//    End namespace sort
+}//    End namespace boost
 //****************************************************************************
 //
 #endif

--- a/include/boost/sort/common/merge_block.hpp
+++ b/include/boost/sort/common/merge_block.hpp
@@ -326,7 +326,7 @@ void merge_block<Iter_t, Compare, Power2>
         while (itxA != indexA.end())
             *(itx_out++) = *(itxA++);
     };
-};
+}
 
 //-------------------------------------------------------------------------
 //  function : move_range_pos_backward
@@ -365,7 +365,7 @@ void merge_block<Iter_t, Compare, Power2>
         util::move_backward(it_mid2, it_mid1, rng1.last);
         util::move_backward(rng1.last, rng1.first, it_mid1);
     };
-};
+}
 //-------------------------------------------------------------------------
 //  function : rearrange_with_index
 /// @brief rearrange the blocks with the relative positions of the index
@@ -408,11 +408,11 @@ void merge_block<Iter_t, Compare, Power2>
         index[pos_dest] = pos_dest;
         ++pos_ini;
     };
-};
+}
 
 //****************************************************************************
-};//    End namespace common
-};//    End namespace sort
-};//    End namespace boost
+}//    End namespace common
+}//    End namespace sort
+}//    End namespace boost
 //****************************************************************************
 #endif

--- a/include/boost/sort/common/merge_four.hpp
+++ b/include/boost/sort/common/merge_four.hpp
@@ -57,7 +57,7 @@ inline bool less_range(Iter_t it1, uint32_t pos1, Iter_t it2, uint32_t pos2,
 {
     return (comp(*it1, *it2)) ? true :
            (pos2 < pos1) ? false : not (comp(*it2, *it1));
-};
+}
 
 //-----------------------------------------------------------------------------
 //  function : full_merge4
@@ -96,17 +96,17 @@ range<Iter1_t> full_merge4(const range<Iter1_t> &rdest,
             for (uint32_t k = i + 1; k < nrange_input; ++k)
             {
                 vrange_input[k - 1] = vrange_input[k];
-            };
+            }
             --nrange_input;
-        };
-    };
+        }
+    }
 
     if (nrange_input == 0) return range1_t(rdest.first, rdest.first);
     if (nrange_input == 1) return move_forward(rdest, vrange_input[0]);
     if (nrange_input == 2)
     {
         return merge(rdest, vrange_input[0], vrange_input[1], comp);
-    };
+    }
 
     //------------------------------------------------------------------------
     // Initial sort
@@ -122,12 +122,12 @@ range<Iter1_t> full_merge4(const range<Iter1_t> &rdest,
                     vrange_input[pos[0]].first, pos[0], comp))
     {
         swap(pos[0], pos[1]);
-    };
+    }
     if (npos == 4 and less_range(vrange_input[pos[3]].first, pos[3],
                                  vrange_input[pos[2]].first, pos[2], comp))
     {
         swap(pos[3], pos[2]);
-    };
+    }
     if (less_range (vrange_input[pos[2]].first, pos[2],
                     vrange_input[pos[0]].first, pos[0], comp))
     {
@@ -138,12 +138,12 @@ range<Iter1_t> full_merge4(const range<Iter1_t> &rdest,
                                     vrange_input[pos[1]].first, pos[1], comp))
     {
         swap(pos[1], pos[3]);
-    };
+    }
     if (less_range (vrange_input[pos[2]].first, pos[2],
                     vrange_input[pos[1]].first, pos[1], comp))
     {
         swap(pos[1], pos[2]);
-    };
+    }
 
     Iter1_t it_dest = rdest.first;
     while (npos > 2)
@@ -173,11 +173,11 @@ range<Iter1_t> full_merge4(const range<Iter1_t> &rdest,
                                                     pos[2], comp))
                     {
                         swap(pos[2], pos[3]);
-                    };
-                };
-            };
-        };
-    };
+                    }
+                }
+            }
+        }
+    }
 
     range1_t raux1(rdest.first, it_dest), raux2(it_dest, rdest.last);
     if (pos[0] < pos[1])
@@ -189,8 +189,8 @@ range<Iter1_t> full_merge4(const range<Iter1_t> &rdest,
     {
         return concat(raux1, merge (raux2, vrange_input[pos[1]], 
                                     vrange_input[pos[0]], comp));
-    };
-};
+    }
+}
 
 //-----------------------------------------------------------------------------
 //  function : uninit_full_merge4
@@ -236,7 +236,7 @@ range<Value_t *> uninit_full_merge4(const range<Value_t *> &dest,
     if (nrange_input == 2)
     {
         return merge_construct(dest, vrange_input[0], vrange_input[1], comp);
-    };
+    }
 
     //------------------------------------------------------------------------
     // Initial sort
@@ -319,13 +319,13 @@ range<Value_t *> uninit_full_merge4(const range<Value_t *> &dest,
         return concat(raux1,
                       merge_construct(raux2, vrange_input[pos[1]],
                                       vrange_input[pos[0]], comp));
-    };
-};
+    }
+}
 
 //****************************************************************************
-};//    End namespace common
-};//    End namespace sort
-};//    End namespace boost
+}//    End namespace common
+}//    End namespace sort
+}//    End namespace boost
 //****************************************************************************
 //
 #endif

--- a/include/boost/sort/common/merge_vector.hpp
+++ b/include/boost/sort/common/merge_vector.hpp
@@ -67,7 +67,7 @@ void merge_level4(range<Iter1_t> dest, std::vector<range<Iter2_t> > &v_input,
     {
         v_output.emplace_back(move_forward(dest, v_input[0]));
         return;
-    };
+    }
 
     uint32_t nrange = v_input.size();
     uint32_t pos_ini = 0;
@@ -80,9 +80,9 @@ void merge_level4(range<Iter1_t> dest, std::vector<range<Iter2_t> > &v_input,
         dest.first = rz.last;
         pos_ini += nelem;
         nrange -= nelem;
-    };
+    }
     return;
-};
+}
 //
 //-----------------------------------------------------------------------------
 //  function : uninit_merge_level4
@@ -129,7 +129,7 @@ void uninit_merge_level4(range<Value_t *> dest,
         nrange -= nelem;
     };
     return;
-};
+}
 //
 //-----------------------------------------------------------------------------
 //  function : merge_vector4
@@ -187,12 +187,12 @@ range<Iter2_t> merge_vector4(range<Iter1_t> range_input,
         };
     };
     return (sw) ? v_output[0] : move_forward(range_output, v_input[0]);
-};
+}
 
 //****************************************************************************
-};//    End namespace common
-};//    End namespace sort
-};//    End namespace boost
+}//    End namespace common
+}//    End namespace sort
+}//    End namespace boost
 //****************************************************************************
 //
 #endif

--- a/include/boost/sort/common/pivot.hpp
+++ b/include/boost/sort/common/pivot.hpp
@@ -50,7 +50,7 @@ inline Iter_t mid3 (Iter_t iter_1, Iter_t iter_2, Iter_t iter_3, Compare comp)
 		if (comp (*iter_2, *iter_1)) swap ( *iter_2, *iter_1);
 	};
 	return iter_2;
-};
+}
 //
 //-----------------------------------------------------------------------------
 //  function : pivot3
@@ -69,7 +69,7 @@ inline void pivot3 (Iter_t first, Iter_t last, Compare comp)
     auto N2 = (last - first) >> 1;
     Iter_t it_val = mid3 (first + 1, first + N2, last - 1, comp);
     swap (*first, *it_val);
-};
+}
 
 //
 //-----------------------------------------------------------------------------
@@ -96,7 +96,7 @@ inline Iter_t mid9 (Iter_t iter_1, Iter_t iter_2, Iter_t iter_3, Iter_t iter_4,
     return mid3 (mid3 (iter_1, iter_2, iter_3, comp),
                  mid3 (iter_4, iter_5, iter_6, comp),
                  mid3 (iter_7, iter_8, iter_9, comp), comp);
-};
+}
 //
 //-----------------------------------------------------------------------------
 //  function : pivot9
@@ -118,10 +118,10 @@ inline void pivot9 (Iter_t first, Iter_t last, Compare comp)
                          first + 3 * cupo, first + 4 * cupo, first + 5 * cupo,
                          first + 6 * cupo, first + 7 * cupo, last - 1, comp);
     swap (*first, *itaux);
-};
+}
 //****************************************************************************
-};//    End namespace common
-};//    End namespace sort
-};//    End namespace boost
+}//    End namespace common
+}//    End namespace sort
+}//    End namespace boost
 //****************************************************************************
 #endif

--- a/include/boost/sort/common/range.hpp
+++ b/include/boost/sort/common/range.hpp
@@ -109,7 +109,7 @@ inline range<Iter_t> concat(const range<Iter_t> &it1, const range<Iter_t> &it2)
 {
     return range<Iter_t>(it1.first, it2.last);
 }
-;
+
 //
 //-----------------------------------------------------------------------------
 //  function : move_forward
@@ -125,7 +125,8 @@ inline range<Iter2_t> move_forward(const range<Iter2_t> &dest,
     assert(dest.size() >= src.size());
     Iter2_t it_aux = util::move_forward(dest.first, src.first, src.last);
     return range<Iter2_t>(dest.first, it_aux);
-};
+}
+
 //
 //-----------------------------------------------------------------------------
 //  function : move_backward
@@ -142,7 +143,7 @@ inline range<Iter2_t> move_backward(const range<Iter2_t> &dest,
     Iter2_t it_aux = util::move_backward(dest.first + src.size(), src.first,
                     src.last);
     return range<Iter2_t>(dest.first, dest.src.size());
-};
+}
 
 //-----------------------------------------------------------------------------
 //  function : uninit_move
@@ -158,7 +159,8 @@ inline range<Value_t*> move_construct(const range<Value_t*> &dest,
 {
     Value_t *ptr_aux = util::move_construct(dest.first, src.first, src.last);
     return range<Value_t*>(dest.first, ptr_aux);
-};
+}
+
 //
 //-----------------------------------------------------------------------------
 //  function : destroy
@@ -169,7 +171,8 @@ template<class Iter_t>
 inline void destroy(range<Iter_t> rng)
 {
     util::destroy(rng.first, rng.last);
-};
+}
+
 //
 //-----------------------------------------------------------------------------
 //  function : initialize
@@ -183,7 +186,8 @@ inline range<Iter_t> initialize(const range<Iter_t> &rng, Value_t &val)
 {
     util::initialize(rng.first, rng.last, val);
     return rng;
-};
+}
+
 //
 //-----------------------------------------------------------------------------
 //  function : is_mergeable
@@ -209,7 +213,8 @@ inline bool is_mergeable(const range<Iter1_t> &src1, const range<Iter2_t> &src2,
     //                 Code
     //------------------------------------------------------------------------
     return comp(*(src2.front()), *(src1.back()));
-};
+}
+
 //
 //-----------------------------------------------------------------------------
 //  function : is_mergeable_stable
@@ -235,7 +240,8 @@ inline bool is_mergeable_stable(const range<Iter1_t> &src1,
     //                 Code
     //------------------------------------------------------------------------
     return ! comp(*(src1.back()), *(src2.front()));
-};
+}
+
 //
 //-----------------------------------------------------------------------------
 //  function : merge
@@ -258,7 +264,7 @@ inline range<Iter3_t> merge(const range<Iter3_t> &dest,
     Iter3_t it_aux = util::merge(src1.first, src1.last, src2.first, src2.last,
                     dest.first, comp);
     return range<Iter3_t>(dest.first, it_aux);
-};
+}
 
 //-----------------------------------------------------------------------------
 //  function : merge_construct
@@ -283,7 +289,8 @@ inline range<Value_t *> merge_construct(const range<Value_t *> &dest,
     Value_t * ptr_aux = util::merge_construct(src1.first, src1.last, src2.first,
                     src2.last, dest.first, comp);
     return range<Value_t*>(dest.first, ptr_aux);
-};
+}
+
 //
 //---------------------------------------------------------------------------
 //  function : half_merge
@@ -306,7 +313,8 @@ inline range<Iter2_t> merge_half(const range<Iter2_t> &dest,
     Iter2_t it_aux = util::merge_half(src1.first, src1.last, src2.first,
                     src2.last, dest.first, comp);
     return range<Iter2_t>(dest.first, it_aux);
-};
+}
+
 //
 //-----------------------------------------------------------------------------
 //  function : merge_uncontiguous
@@ -326,7 +334,8 @@ inline bool merge_uncontiguous(const range<Iter1_t> &src1,
 {
     return util::merge_uncontiguous(src1.first, src1.last, src2.first,
                     src2.last, aux.first, comp);
-};
+}
+
 //
 //-----------------------------------------------------------------------------
 //  function : merge_contiguous
@@ -345,7 +354,8 @@ inline range<Iter1_t> merge_contiguous(const range<Iter1_t> &src1,
 {
     util::merge_contiguous(src1.first, src1.last, src2.last, buf.first, comp);
     return concat(src1, src2);
-};
+}
+
 //
 //-----------------------------------------------------------------------------
 //  function : merge_flow
@@ -389,12 +399,12 @@ static void merge_flow(range<Iter1_t> rng1, range<Iter2_t> rbuf,
     if (rx2.first == rx2.last) return;
     if (rbx.first == rbx.last) move_forward(rbuf, rng2);
     else                       merge_half(rbuf, rx2, rbx, cmp);
-};
+}
 
 //****************************************************************************
-};//    End namespace common
-};//    End namespace sort
-};//    End namespace boost
+}//    End namespace common
+}//    End namespace sort
+}//    End namespace boost
 //****************************************************************************
 //
 #endif

--- a/include/boost/sort/common/rearrange.hpp
+++ b/include/boost/sort/common/rearrange.hpp
@@ -101,7 +101,7 @@ void rearrange(Iter_data global_first, Iter_index itx_first,
         index[pos_ini] = std::move(itx_src);
         ++pos_ini;
     };
-};
+}
 
 /*
  //
@@ -161,9 +161,9 @@ void rearrange(Iter_data global_first, Iter_index itx_first,
  */
 //
 //****************************************************************************
-};//    End namespace common
-};//    End namespace sort
-};//    End namespace boost
+}//    End namespace common
+}//    End namespace sort
+}//    End namespace boost
 //****************************************************************************
 //
 #endif

--- a/include/boost/sort/common/sort_basic.hpp
+++ b/include/boost/sort/common/sort_basic.hpp
@@ -80,7 +80,7 @@ inline Iter_t is_reverse_stable_sorted_forward(Iter_t first, Iter_t last,
     Iter_t it2 = first + 1;
     for (Iter_t it1 = first; it2 != last && comp(*it2, *it1); it1 = it2++);
     return it2;
-};
+}
 //-----------------------------------------------------------------------------
 //  function : number_stable_sorted_forward
 /// @brief examine the elements in the range first, last if they are stable
@@ -117,7 +117,7 @@ size_t number_stable_sorted_forward (Iter_t first, Iter_t last,
     if ( nsorted < min_process) return 0 ;
     util::reverse ( first , it2);
     return nsorted;
-};
+}
 
 //-----------------------------------------------------------------------------
 //  function : is_stable_sorted_backward
@@ -248,7 +248,7 @@ inline void internal_sort (const range<Iter1_t> &rng1,
         internal_sort(rng2_right, rng1_right, comp, level + 1, even);
     };
     merge(rng2, rng1_left, rng1_right, comp);
-};
+}
 //-----------------------------------------------------------------------------
 //  function : range_sort_data
 /// @brief this sort elements using the range_sort function and receiving a
@@ -285,7 +285,7 @@ static void range_sort_data (const range<Iter1_t> & rng_data,
     };
 
     internal_sort(rng_aux, rng_data, comp, 0, true);
-};
+}
 //-----------------------------------------------------------------------------
 //  function : range_sort_buffer
 /// @brief this sort elements using the range_sort function and receiving a
@@ -323,11 +323,11 @@ static void range_sort_buffer(const range<Iter1_t> & rng_data,
     };
 
     internal_sort(rng_data, rng_aux, comp, 0, false);
-};
+}
 //****************************************************************************
-};//    End namespace common
-};//    End namespace sort
-};//    End namepspace boost
+}//    End namespace common
+}//    End namespace sort
+}//    End namepspace boost
 //****************************************************************************
 //
 #endif

--- a/include/boost/sort/common/spinlock.hpp
+++ b/include/boost/sort/common/spinlock.hpp
@@ -48,7 +48,7 @@ class spinlock_t
     /// @brief  class constructor
     /// @param [in]
     //-------------------------------------------------------------------------
-    explicit spinlock_t ( ) noexcept { af.clear ( ); };
+    explicit spinlock_t ( ) noexcept { af.clear ( ); }
     //
     //-------------------------------------------------------------------------
     //  function : lock
@@ -59,8 +59,8 @@ class spinlock_t
     	while (af.test_and_set (std::memory_order_acquire))
         {
             std::this_thread::yield ( );
-        };
-    };
+        }
+    }
     //
     //-------------------------------------------------------------------------
     //  function : try_lock
@@ -71,19 +71,19 @@ class spinlock_t
     bool try_lock ( ) noexcept
     {
         return !af.test_and_set (std::memory_order_acquire);
-    };
+    }
     //
     //-------------------------------------------------------------------------
     //  function : unlock
     /// @brief  unlock the spinlock_t
     //-------------------------------------------------------------------------
-    void unlock ( ) noexcept { af.clear (std::memory_order_release); };
+    void unlock ( ) noexcept { af.clear (std::memory_order_release); }
 
 }; // E N D    C L A S S     S P I N L O C K
 //
 //***************************************************************************
-}; // end namespace common
-}; // end namespace sort
-}; // end namespace boost
+} // end namespace common
+} // end namespace sort
+} // end namespace boost
 //***************************************************************************
 #endif

--- a/include/boost/sort/common/stack_cnc.hpp
+++ b/include/boost/sort/common/stack_cnc.hpp
@@ -73,7 +73,7 @@ public:
     //  function : stack_cnc
     /// @brief  constructor
     //-------------------------------------------------------------------------
-    explicit stack_cnc(void): v_t() { };
+    explicit stack_cnc(void): v_t() { }
 
     //
     //-------------------------------------------------------------------------
@@ -86,7 +86,7 @@ public:
     //  function : ~stack_cnc
     /// @brief  Destructor
     //-------------------------------------------------------------------------
-    virtual ~stack_cnc(void) { v_t.clear(); };
+    virtual ~stack_cnc(void) { v_t.clear(); }
 
     //-------------------------------------------------------------------------
     //  function : emplace_back
@@ -137,8 +137,8 @@ public:
 // end class stack_cnc
 
 //***************************************************************************
-};// end namespace common
-};// end namespace sort
-};// end namespace boost
+} // end namespace common
+} // end namespace sort
+} // end namespace boost
 //***************************************************************************
 #endif

--- a/include/boost/sort/common/util/algorithm.hpp
+++ b/include/boost/sort/common/util/algorithm.hpp
@@ -144,7 +144,7 @@ template <class Value_t, class ... Args>
 inline void construct_object (Value_t *ptr, Args &&... args)
 {
     (::new (static_cast<void *>(ptr)) Value_t(std::forward< Args > (args)...));
-};
+}
 //
 //-----------------------------------------------------------------------------
 //  function : destroy_object
@@ -155,7 +155,7 @@ template<class Value_t>
 inline void destroy_object(Value_t *ptr)
 {
     ptr->~Value_t();
-};
+}
 //
 //-----------------------------------------------------------------------------
 //  function : initialize
@@ -185,9 +185,9 @@ inline void initialize (Iter_t first, Iter_t last, Value_t & val)
     while (it2 != last)
     {
         construct_object(&(*(it2++)), std::move(*(it1++)));
-    };
+    }
     val = std::move(*(last - 1));
-};
+}
 //
 //-----------------------------------------------------------------------------
 //  function : move_forward
@@ -216,8 +216,8 @@ inline Iter2_t move_forward (Iter2_t it_dest, Iter1_t first, Iter1_t last)
     {   *it_dest++ = std::move(*first++);
     }
     return it_dest;
+}
 
-};
 //
 //-----------------------------------------------------------------------------
 //  function : move_backard
@@ -244,7 +244,7 @@ inline Iter2_t move_backward(Iter2_t it_dest, Iter1_t  first, Iter1_t last)
     {   *(--it_dest) = std::move (*(--last));
     }
     return it_dest;
-};
+}
 
 //
 //-----------------------------------------------------------------------------
@@ -271,9 +271,9 @@ inline Value_t * move_construct(Value_t *ptr, Iter_t first, Iter_t last)
     while (first != last)
     {
         ::new (static_cast<void *>(ptr++)) Value_t(std::move(*(first++)));
-    };
+    }
     return ptr;
-};
+}
 //
 //-----------------------------------------------------------------------------
 //  function : destroy
@@ -286,7 +286,7 @@ inline void destroy(Iter_t first, const Iter_t last)
 {
     while (first != last)
         destroy_object(&(*(first++)));
-};
+}
 //
 //-----------------------------------------------------------------------------
 //  function : reverse
@@ -298,13 +298,13 @@ template<class Iter_t>
 inline void reverse(Iter_t first, Iter_t last)
 {
     std::reverse ( first, last);
-};
+}
 //
 //****************************************************************************
-};//    End namespace util
-};//    End namespace common
-};//    End namespace sort
-};//    End namespace boost
+} //    End namespace util
+} //    End namespace common
+} //    End namespace sort
+} //    End namespace boost
 //****************************************************************************
 //
 #endif

--- a/include/boost/sort/common/util/atomic.hpp
+++ b/include/boost/sort/common/util/atomic.hpp
@@ -35,7 +35,7 @@ template<typename T>
 inline T atomic_read(std::atomic<T> &at_var)
 {
     return std::atomic_load_explicit < T > (&at_var, std::memory_order_acquire);
-};
+}
 //
 //-----------------------------------------------------------------------------
 //  function : atomic_add
@@ -50,7 +50,7 @@ inline T atomic_add(std::atomic<T> &at_var, T2 num)
     static_assert (std::is_integral< T2 >::value, "Bad parameter");
     return std::atomic_fetch_add_explicit <T> 
                                (&at_var, (T) num, std::memory_order_acq_rel);
-};
+}
 //
 //-----------------------------------------------------------------------------
 //  function : atomic_sub
@@ -65,7 +65,7 @@ inline T atomic_sub(std::atomic<T> &at_var, T2 num)
     static_assert (std::is_integral< T2 >::value, "Bad parameter");
     return std::atomic_fetch_sub_explicit <T> 
                                 (&at_var, (T) num, std::memory_order_acq_rel);
-};
+}
 //
 //-----------------------------------------------------------------------------
 //  function : atomic_write
@@ -79,21 +79,21 @@ inline void atomic_write(std::atomic<T> &at_var, T2 num)
     static_assert (std::is_integral< T2 >::value, "Bad parameter");
     std::atomic_store_explicit <T> 
                                 (&at_var, (T) num, std::memory_order_release);
-};
+}
 template<typename T>
 struct counter_guard
 {
     typedef std::atomic<T> atomic_t;
     atomic_t &count;
 
-    counter_guard(atomic_t & counter): count(counter) { };
-    ~counter_guard() {atomic_sub(count, 1); };
+    counter_guard(atomic_t & counter): count(counter) { }
+    ~counter_guard() {atomic_sub(count, 1); }
 };
 //
 //****************************************************************************
-};// End namespace util
-};// End namespace common
-};// End namespace sort
-};// End namespace boost
+} // End namespace util
+} // End namespace common
+} // End namespace sort
+} // End namespace boost
 //****************************************************************************
 #endif

--- a/include/boost/sort/common/util/circular_buffer.hpp
+++ b/include/boost/sort/common/util/circular_buffer.hpp
@@ -73,7 +73,7 @@ struct circular_buffer
     {
         ptr = static_cast <Value_t*> (std::malloc (NMAX * sizeof(Value_t)));
         if (ptr == nullptr) throw std::bad_alloc();
-    };
+    }
     //
     //------------------------------------------------------------------------
     //  function : ~circular_buffer
@@ -84,7 +84,7 @@ struct circular_buffer
         if (initialized)
         {   for (size_t i = 0; i < NMAX; ++i) (ptr + i)->~Value_t();
             initialized = false;
-        };
+        }
         std::free(static_cast <void*> (ptr));
     }
     ;
@@ -103,61 +103,61 @@ struct circular_buffer
             ::new (static_cast<void*>(ptr + i)) Value_t(std::move(ptr[i - 1]));
         val = std::move(ptr[NMAX - 1]);
         initialized = true;
-    };
+    }
     //
     //------------------------------------------------------------------------
     //  function : destroy_all
     /// @brief : destroy all the objects in the internal memory
     //-----------------------------------------------------------------------
-    void destroy_all(void) { destroy(ptr, ptr + NMAX); };
+    void destroy_all(void) { destroy(ptr, ptr + NMAX); }
     //
     //------------------------------------------------------------------------
     //  function : get_buffer
     /// @brief return the internal memory of the circular buffer
     /// @return pointer to the internal memory of the buffer
     //-----------------------------------------------------------------------
-    Value_t * get_buffer(void) { return ptr; };
+    Value_t * get_buffer(void) { return ptr; }
     //
     //------------------------------------------------------------------------
     //  function : empty
     /// @brief return if the buffer is empty
     /// @return true : empty
     //-----------------------------------------------------------------------
-    bool empty(void) const {return (nelem == 0); };
+    bool empty(void) const {return (nelem == 0); }
     //
     //------------------------------------------------------------------------
     //  function : full
     /// @brief return if the buffer is full
     /// @return true : full
     //-----------------------------------------------------------------------
-    bool full(void) const { return (nelem == NMAX); };
+    bool full(void) const { return (nelem == NMAX); }
     //
     //------------------------------------------------------------------------
     //  function : size
     /// @brief return the number of elements stored in the buffer
     /// @return number of elements stored
     //-----------------------------------------------------------------------
-    size_t size(void) const { return nelem;};
+    size_t size(void) const { return nelem;}
     //
     //------------------------------------------------------------------------
     //  function : capacity
     /// @brief : return the maximun capacity of the buffer
     /// @return number of elements
     //-----------------------------------------------------------------------
-    size_t capacity(void) const { return NMAX;};
+    size_t capacity(void) const { return NMAX;}
     //
     //------------------------------------------------------------------------
     //  function : free_size
     /// @brief return the free positions in the buffer
     /// @return number of elements
     //-----------------------------------------------------------------------
-    size_t free_size(void) const  { return (NMAX - nelem); };
+    size_t free_size(void) const  { return (NMAX - nelem); }
     //
     //------------------------------------------------------------------------
     //  function : clear
     /// @brief clear the buffer
     //-----------------------------------------------------------------------
-    void clear(void)  { nelem = first_pos = 0; };
+    void clear(void)  { nelem = first_pos = 0; }
     //
     //------------------------------------------------------------------------
     //  function : front
@@ -170,7 +170,7 @@ struct circular_buffer
         assert (nelem > 0);
 #endif
         return (ptr[first_pos]);
-    };
+    }
     //
     //------------------------------------------------------------------------
     //  function :front
@@ -183,7 +183,7 @@ struct circular_buffer
         assert ( nelem > 0 );
 #endif
         return (ptr[first_pos]);
-    };
+    }
     //
     //------------------------------------------------------------------------
     //  function : back
@@ -196,7 +196,7 @@ struct circular_buffer
         assert ( nelem > 0 );
 #endif
         return (ptr[(first_pos + nelem - 1) & MASK]);
-    };
+    }
     //
     //------------------------------------------------------------------------
     //  function : back
@@ -209,7 +209,7 @@ struct circular_buffer
         assert ( nelem > 0 );
 #endif
         return (ptr[(first_pos + nelem - 1) & MASK]);
-    };
+    }
     //
     //------------------------------------------------------------------------
     //  function : operator []
@@ -223,7 +223,7 @@ struct circular_buffer
         assert ( nelem > 0 );
 #endif
         return ptr[(first_pos + pos) & MASK];
-    };
+    }
     //
     //------------------------------------------------------------------------
     //  function : operator []
@@ -238,7 +238,7 @@ struct circular_buffer
         assert ( nelem > 0 );
 #endif
         return ptr[(first_pos + pos) & MASK];
-    };
+    }
     //
     //------------------------------------------------------------------------
     //  function : push_front
@@ -254,7 +254,7 @@ struct circular_buffer
         first_pos = ((first_pos + MASK) & MASK);
         ptr[first_pos] = val;
 
-    };
+    }
     //
     //------------------------------------------------------------------------
     //  function : push_front
@@ -269,7 +269,7 @@ struct circular_buffer
         ++nelem;
         first_pos = ((first_pos + MASK) & MASK);
         ptr[first_pos] = val;
-    };
+    }
     //
     //------------------------------------------------------------------------
     //  function : push_back
@@ -282,7 +282,7 @@ struct circular_buffer
         assert ( nelem != NMAX);
 #endif
         ptr[(first_pos + (nelem++)) & MASK] = val;
-    };
+    }
     //
     //------------------------------------------------------------------------
     //  function : push_back
@@ -295,7 +295,7 @@ struct circular_buffer
         assert ( nelem != NMAX);
 #endif
         ptr[(first_pos + (nelem++)) & MASK] = std::move(val);
-    };
+    }
     //
     //------------------------------------------------------------------------
     //  function : pop_front
@@ -308,7 +308,7 @@ struct circular_buffer
 #endif
         --nelem;
         (++first_pos) &= MASK;
-    };
+    }
     //
     //------------------------------------------------------------------------
     //  function : pop_back
@@ -320,7 +320,7 @@ struct circular_buffer
         assert ( nelem > 0 );
 #endif
         --nelem;
-    };
+    }
 
     template<class iter_t>
     void pop_copy_front(iter_t it_dest, size_t num);
@@ -380,9 +380,9 @@ void circular_buffer<Value_t, Power2>
     for (size_t i = 0; i < num; ++i)
     {
         *(it_dest++) = ptr[pos++ & MASK];
-    };
+    }
     first_pos &= MASK;
-};
+}
 //
 //------------------------------------------------------------------------
 //  function : pop_move_front
@@ -408,9 +408,9 @@ void circular_buffer<Value_t, Power2>
     for (size_t i = 0; i < num; ++i)
     {
         *(it_dest++) = std::move(ptr[pos++ & MASK]);
-    };
+    }
     first_pos &= MASK;
-};
+}
 //
 //------------------------------------------------------------------------
 //  function : pop_copy_back
@@ -434,8 +434,8 @@ void circular_buffer<Value_t, Power2>
     for (size_t i = 0; i < num; ++i)
     {
         *(it_dest++) = ptr[pos++ & MASK];
-    };
-};
+    }
+}
 //
 //------------------------------------------------------------------------
 //  function : pop_move_back
@@ -459,8 +459,8 @@ void circular_buffer<Value_t, Power2>
     for (size_t i = 0; i < num; ++i)
     {
         *(it_dest++) = std::move(ptr[pos++ & MASK]);
-    };
-};
+    }
+}
 //
 //------------------------------------------------------------------------
 //  function : push_copy_front
@@ -486,8 +486,8 @@ void circular_buffer<Value_t, Power2>
     for (size_t i = 0; i < num; ++i)
     {
         ptr[(pos++) & MASK] = *(it_src++);
-    };
-};
+    }
+}
 //
 //------------------------------------------------------------------------
 //  function : push_move_front
@@ -511,8 +511,8 @@ void circular_buffer<Value_t, Power2>
     for (size_t i = 0; i < num; ++i)
     {
         ptr[(pos++) & MASK] = std::move(*(it_src++));
-    };
-};
+    }
+}
 //
 //------------------------------------------------------------------------
 //  function : push_copy_back
@@ -536,8 +536,8 @@ void circular_buffer<Value_t, Power2>
     for (size_t i = 0; i < num; ++i)
     {
         ptr[(pos++) & MASK] = *(it_src++);
-    };
-};
+    }
+}
 //
 //------------------------------------------------------------------------
 //  function : push_move_back
@@ -561,13 +561,13 @@ void circular_buffer<Value_t, Power2>
     for (size_t i = 0; i < num; ++i)
     {
         ptr[(pos++) & MASK] = std::move(*(it_src++));
-    };
-};
+    }
+}
 
 //****************************************************************************
-};// End namespace util
-};// End namespace common
-};// End namespace sort
-};// End namespace boost
+} // End namespace util
+} // End namespace common
+} // End namespace sort
+} // End namespace boost
 //****************************************************************************
 #endif

--- a/include/boost/sort/common/util/insert.hpp
+++ b/include/boost/sort/common/util/insert.hpp
@@ -91,8 +91,8 @@ static void insert_sorted(Iter1_t first, Iter1_t mid, Iter1_t last,
         mv_first = std::upper_bound(first, mv_last, it_aux[i - 1], comp);
         Iter1_t it1 = here::move_backward(mv_last + i, mv_first, mv_last);
         *(it1 - 1) = std::move(it_aux[i - 1]);
-    };
-};
+    }
+}
 
 template<class Iter1_t, class Iter2_t, typename Compare>
 static void insert_sorted_backward(Iter1_t first, Iter1_t mid, Iter1_t last,
@@ -128,15 +128,15 @@ static void insert_sorted_backward(Iter1_t first, Iter1_t mid, Iter1_t last,
         mv_last = std::lower_bound(mv_first, last, it_aux[i], comp);
         Iter1_t it1 = move_forward(mv_first - (ndata - i), mv_first, mv_last);
         *(it1) = std::move(it_aux[i]);
-    };
+    }
 
-};
+}
 //
 //****************************************************************************
-};//    End namespace util
-};//    End namepspace common
-};//    End namespace sort
-};//    End namepspace boost
+} //    End namespace util
+} //    End namepspace common
+} //    End namespace sort
+} //    End namepspace boost
 //****************************************************************************
 //
 #endif

--- a/include/boost/sort/common/util/merge.hpp
+++ b/include/boost/sort/common/util/merge.hpp
@@ -110,19 +110,19 @@ static Iter3_t merge(Iter1_t buf1, const Iter1_t end_buf1, Iter2_t buf2,
         {
             Iter3_t mid = move_forward(buf_out, buf1, end_buf1);
             return move_forward(mid, buf2, end_buf2);
-        };
+        }
 
         if (comp(*(end_buf2 - 1), *buf1))
         {
             Iter3_t mid = move_forward(buf_out, buf2, end_buf2);
             return move_forward(mid, buf1, end_buf1);
-        };
-    };
+        }
+    }
     while ((buf1 != end_buf1) && (buf2 != end_buf2))
     {
         *(buf_out++) = (! comp(*buf2, *buf1)) ?
                         std::move(*(buf1++)) : std::move(*(buf2++));
-    };
+    }
 
     return (buf1 == end_buf1) ?
                     move_forward(buf_out, buf2, end_buf2) :
@@ -171,25 +171,25 @@ static Value_t *merge_construct(Iter1_t first1, const Iter1_t last1,
         {
             Value_t* mid = move_construct(it_out, first1, last1);
             return move_construct(mid, first2, last2);
-        };
+        }
 
         if (comp(*(last2 - 1), *first1))
         {
             Value_t* mid = move_construct(it_out, first2, last2);
             return move_construct(mid, first1, last1);
-        };
-    };
+        }
+    }
     while (first1 != last1 && first2 != last2)
     {
         construct_object((it_out++),
                         (! comp(*first2, *first1)) ?
                                         std::move(*(first1++)) :
                                         std::move(*(first2++)));
-    };
+    }
     return (first1 == last1) ?
                     move_construct(it_out, first2, last2) :
                     move_construct(it_out, first1, last1);
-};
+}
 //
 //---------------------------------------------------------------------------
 //  function : merge_half
@@ -235,21 +235,21 @@ static Iter2_t merge_half(Iter1_t buf1, const Iter1_t end_buf1, Iter2_t buf2,
         {
             move_forward(buf_out, buf1, end_buf1);
             return end_buf2;
-        };
+        }
 
         if (comp(*(end_buf2 - 1), *buf1))
         {
             Iter2_t mid = move_forward(buf_out, buf2, end_buf2);
             return move_forward(mid, buf1, end_buf1);
-        };
-    };
+        }
+    }
     while ((buf1 != end_buf1) && (buf2 != end_buf2))
     {
         *(buf_out++) = (! comp(*buf2, *buf1)) ?
                         std::move(*(buf1++)) : std::move(*(buf2++));
-    };
+    }
     return (buf2 == end_buf2)? move_forward(buf_out, buf1, end_buf1) : end_buf2;
-};
+}
 
 //
 //---------------------------------------------------------------------------
@@ -298,24 +298,24 @@ static Iter2_t merge_half_backward(Iter1_t buf1, Iter1_t end_buf1, Iter2_t buf2,
         {
             here::move_backward(end_buf_out, buf2, end_buf2);
             return buf1;
-        };
+        }
 
         if (comp(*(end_buf2 - 1), *buf1))
         {
             Iter1_t mid = here::move_backward(end_buf_out, buf1, end_buf1);
             return here::move_backward(mid, buf2, end_buf2);
-        };
-    };
+        }
+    }
     while ((buf1 != end_buf1) && (buf2 != end_buf2))
     {
         *(--end_buf_out) =
                         (! comp(*(end_buf2 - 1), *(end_buf1 - 1))) ?
                                         std::move(*(--end_buf2)):
                                         std::move(*(--end_buf1));
-    };
+    }
     return (buf1 == end_buf1) ?
                     here::move_backward(end_buf_out, buf2, end_buf2) : buf1;
-};
+}
 
 //
 //-----------------------------------------------------------------------------
@@ -375,9 +375,9 @@ static bool merge_uncontiguous(Iter1_t src1, const Iter1_t end_src1,
     else
     {
         merge_half(aux, end_aux, src2, end_src2, src2_first, comp);
-    };
+    }
     return false;
-};
+}
 
 //
 //-----------------------------------------------------------------------------
@@ -421,7 +421,7 @@ static bool merge_contiguous(Iter1_t src1, Iter1_t src2, Iter1_t end_src2,
     move_forward(buf, src1, end_src1);
     merge_half(buf, buf + nx, src2, end_src2, src1, comp);
     return false;
-};
+}
 //
 //-----------------------------------------------------------------------------
 //  function : merge_circular
@@ -465,7 +465,7 @@ static bool merge_circular(Iter1_t buf1, Iter1_t end_buf1, Iter2_t buf2,
         it1_out = end_buf1;
         it2_out = buf2;
         return true;
-    };
+    }
     if (comp(*(end_buf2 - 1), *buf1))
     {
         circ.push_move_back(buf2, (end_buf2 - buf2));
@@ -477,18 +477,18 @@ static bool merge_circular(Iter1_t buf1, Iter1_t end_buf1, Iter2_t buf2,
     {
         circ.push_back(comp(*buf2, *buf1) ? std::move(*(buf2++))
                                           : std::move(*(buf1++)));
-    };
+    }
     it2_out = buf2;
     it1_out = buf1;
     bool ret = (buf1 == end_buf1);
     return ret;
-};
+}
 //
 //****************************************************************************
-};//    End namespace util
-};//    End namespace common
-};//    End namespace sort
-};//    End namespace boost
+} //    End namespace util
+} //    End namespace common
+} //    End namespace sort
+} //    End namespace boost
 //****************************************************************************
 //
 #endif

--- a/include/boost/sort/common/util/merge.hpp
+++ b/include/boost/sort/common/util/merge.hpp
@@ -128,7 +128,7 @@ static Iter3_t merge(Iter1_t buf1, const Iter1_t end_buf1, Iter2_t buf2,
                     move_forward(buf_out, buf2, end_buf2) :
                     move_forward(buf_out, buf1, end_buf1);
 }
-;
+
 //
 //-----------------------------------------------------------------------------
 //  function : merge_construct

--- a/include/boost/sort/common/util/search.hpp
+++ b/include/boost/sort/common/util/search.hpp
@@ -30,7 +30,7 @@ struct filter_pass
     const key & operator()(const T & val) const
     {
         return val;
-    };
+    }
 };
 
 //
@@ -79,9 +79,9 @@ inline Iter_t internal_find_first(Iter_t first, Iter_t last,
         if (comp(flt(*it_out), val))
             LI = it_out + 1;
         else LS = it_out;
-    };
+    }
     return LS;
-};
+}
 //
 //-----------------------------------------------------------------------------
 //  function : internal_find_last
@@ -112,9 +112,9 @@ inline Iter_t internal_find_last(Iter_t first, Iter_t last,
         it_out = LI + ((LS - LI + 1) >> 1);
         if (comp(val, flt(*it_out))) LS = it_out - 1;
         else                         LI = it_out;
-    };
+    }
     return LS;
-};
+}
 
 //
 //###########################################################################
@@ -149,7 +149,7 @@ inline Iter_t find_first(Iter_t first, Iter_t last,
     if (first == last) return last;
     Iter_t LS = internal_find_first(first, last, val, comp, flt);
     return (comp(flt(*LS), val) or comp(val, flt(*LS))) ? last : LS;
-};
+}
 //
 //-----------------------------------------------------------------------------
 //  function : find_last
@@ -174,7 +174,7 @@ inline Iter_t find_last(Iter_t first, Iter_t last,
     if (last == first) return last;
     Iter_t LS = internal_find_last(first, last, val, comp, flt);
     return (comp(flt(*LS), val) or comp(val, flt(*LS))) ? last : LS;
-};
+}
 
 //----------------------------------------------------------------------------
 //  function : lower_bound
@@ -196,7 +196,7 @@ inline Iter_t lower_bound(Iter_t first, Iter_t last,
     if (last == first) return last;
     Iter_t itaux = internal_find_first(first, last, val, comp, flt);
     return (itaux == (last - 1) and comp(flt(*itaux), val)) ? last : itaux;
-};
+}
 //----------------------------------------------------------------------------
 //  function :upper_bound
 /// @brief return the first element greather than val.If don't exist
@@ -242,7 +242,7 @@ inline std::pair<Iter_t, Iter_t> equal_range(Iter_t first, Iter_t last,
 {
     return std::make_pair(lower_bound(first, last, val, comp, flt),
                     upper_bound(first, last, val, comp, flt));
-};
+}
 //
 //-----------------------------------------------------------------------------
 //  function : insert_first
@@ -263,7 +263,7 @@ inline Iter_t insert_first(Iter_t first, Iter_t last,
                                            Filter())
 {
     return lower_bound(first, last, val, comp, flt);
-};
+}
 //
 //-----------------------------------------------------------------------------
 //  function : insert_last
@@ -285,7 +285,7 @@ inline Iter_t insert_last(Iter_t first, Iter_t last,
                                           Filter())
 {
     return upper_bound(first, last, val, comp, flt);
-};
+}
 
 /*
 
@@ -330,9 +330,9 @@ inline Iter_t insert_last(Iter_t first, Iter_t last,
  while ( LI != LS)
  {   it_out = LI + ( (LS - LI) >> 1);
  if ( comp ( *it_out, val)) LI = it_out + 1 ; else LS = it_out ;
- };
+ }
  return LS ;
- };
+ }
  //
  //-----------------------------------------------------------------------------
  //  function : internal_find_last
@@ -359,9 +359,9 @@ inline Iter_t insert_last(Iter_t first, Iter_t last,
  while ( LI != LS)
  {   it_out = LI + ( (LS - LI + 1) >> 1);
  if ( comp (val, *it_out)) LS = it_out - 1 ; else LI = it_out ;
- };
+ }
  return LS ;
- };
+ }
 
  //
  //###########################################################################
@@ -394,7 +394,7 @@ inline Iter_t insert_last(Iter_t first, Iter_t last,
  if ( first == last) return last ;
  Iter_t LS = internal_find_first ( first, last, val, comp);
  return (comp (*LS, val) or comp (val, *LS))?last:LS;
- };
+ }
  //
  //-----------------------------------------------------------------------------
  //  function : find_last
@@ -417,7 +417,7 @@ inline Iter_t insert_last(Iter_t first, Iter_t last,
  if ( last == first ) return last ;
  Iter_t LS = internal_find_last (first, last, val, comp);
  return (comp (*LS, val) or comp (val, *LS))?last:LS ;
- };
+ }
 
  //----------------------------------------------------------------------------
  //  function : lower_bound
@@ -437,7 +437,7 @@ inline Iter_t insert_last(Iter_t first, Iter_t last,
  if ( last == first ) return last ;
  Iter_t  itaux = internal_find_first( first, last, val,comp);
  return (itaux == (last - 1) and comp (*itaux, val))?last: itaux;
- };
+ }
  //----------------------------------------------------------------------------
  //  function :upper_bound
  /// @brief return the first element greather than val.If don't exist
@@ -459,7 +459,7 @@ inline Iter_t insert_last(Iter_t first, Iter_t last,
  if ( last == first ) return last ;
  Iter_t itaux = internal_find_last( first, last, val,comp);
  return ( itaux == first and comp (val,*itaux))? itaux: itaux + 1;
- };
+ }
  //----------------------------------------------------------------------------
  //  function :equal_range
  /// @brief return a pair of lower_bound and upper_bound with the value val.If
@@ -478,7 +478,7 @@ inline Iter_t insert_last(Iter_t first, Iter_t last,
  {
  return std::make_pair(lower_bound(first, last, val,comp),
  upper_bound(first, last, val,comp));
- };
+ }
  //
  //-----------------------------------------------------------------------------
  //  function : insert_first
@@ -497,7 +497,7 @@ inline Iter_t insert_last(Iter_t first, Iter_t last,
  Compare comp = Compare() )
  {
  return lower_bound (first, last, val, comp);
- };
+ }
  //
  //-----------------------------------------------------------------------------
  //  function : insert_last
@@ -517,15 +517,15 @@ inline Iter_t insert_last(Iter_t first, Iter_t last,
  Compare comp = Compare())
  {
  return upper_bound (first, last, val, comp);
- };
+ }
 
  */
 //
 //****************************************************************************
-};//    End namespace util
-};//    End namespace common
-};//    End namespace sort
-};//    End namespace boost
+} //    End namespace util
+} //    End namespace common
+} //    End namespace sort
+} //    End namespace boost
 //****************************************************************************
 //
 #endif

--- a/include/boost/sort/common/util/traits.hpp
+++ b/include/boost/sort/common/util/traits.hpp
@@ -116,9 +116,9 @@ struct constructor
 };
 //
 //****************************************************************************
-};// End namespace util
-};// End namespace common
-};// End namespace sort
-};// End namespace boost
+} // End namespace util
+} // End namespace common
+} // End namespace sort
+} // End namespace boost
 //****************************************************************************
 #endif

--- a/include/boost/sort/flat_stable_sort/flat_stable_sort.hpp
+++ b/include/boost/sort/flat_stable_sort/flat_stable_sort.hpp
@@ -132,7 +132,7 @@ void flat_stable_sort <Iter_t, Compare, Power2>
     divide(itx_first, itx_first + nblock1);
     divide(itx_first + nblock1, itx_last);
     merge_range_pos(itx_first, itx_first + nblock1, itx_last);
-};
+}
 //
 //------------------------------------------------------------------------
 //  @fn sort_small
@@ -168,7 +168,7 @@ void flat_stable_sort <Iter_t, Compare, Power2>
     range_sort_data(rng_data2, rng_aux2, cmp);
     range_sort_buffer(rng_data1, rng_aux1, cmp);
     merge_half(rng_data, rng_aux1, rng_data2, cmp);
-};
+}
 //
 //------------------------------------------------------------------------
 //  @fn is_sorted_forward
@@ -209,7 +209,7 @@ bool flat_stable_sort <Iter_t, Compare, Power2>
         merge_range_pos(itx_first, itx_first + nblock1, itx_last);
     };
     return true;
-};
+}
 //
 //------------------------------------------------------------------------
 //  @fn is_sorted_backward
@@ -250,9 +250,9 @@ bool flat_stable_sort <Iter_t, Compare, Power2>
         merge_range_pos(itx_first, itx_first + nblock1, itx_last);
     };
     return true;
-};
+}
 //****************************************************************************
-};// End namespace flat_internal
+}// End namespace flat_internal
 //****************************************************************************
 //
 namespace bscu = boost::sort::common::util;
@@ -270,7 +270,7 @@ inline void flat_stable_sort (Iter_t first, Iter_t last,
                                  Compare cmp = Compare())
 {
     flat::flat_stable_sort<Iter_t, Compare, 6> (first, last, cmp);
-};
+}
 
 template<size_t Size>
 struct block_size_fss
@@ -297,7 +297,7 @@ inline void flat_stable_sort (Iter_t first, Iter_t last,
     flat::flat_stable_sort<Iter_t, Compare,
                            block_size_fss<sizeof(value_iter<Iter_t> )>::data>
         (first, last, cmp);
-};
+}
 
 template<class Iter_t, class Compare = compare_iter<Iter_t> >
 inline void indirect_flat_stable_sort (Iter_t first, Iter_t last,
@@ -307,11 +307,11 @@ inline void indirect_flat_stable_sort (Iter_t first, Iter_t last,
     typedef common::less_ptr_no_null <Iter_t, Compare> itx_comp;
     common::indirect_sort ( flat_stable_sort<itx_iter, itx_comp>,
                             first, last, comp);
-};
+}
 
 //****************************************************************************
-};//    End namespace sort
-};//    End namepspace boost
+}//    End namespace sort
+}//    End namepspace boost
 //****************************************************************************
 //
 #endif

--- a/include/boost/sort/insert_sort/insert_sort.hpp
+++ b/include/boost/sort/insert_sort/insert_sort.hpp
@@ -57,12 +57,12 @@ static void insert_sort (Iter_t first, Iter_t last,
         };
         *it_insertion = std::move (Aux);
     };
-};
+}
 
 //
 //****************************************************************************
-}; //    End namespace sort
-}; //    End namespace boost
+} //    End namespace sort
+} //    End namespace boost
 //****************************************************************************
 //
 #endif

--- a/include/boost/sort/parallel_stable_sort/parallel_stable_sort.hpp
+++ b/include/boost/sort/parallel_stable_sort/parallel_stable_sort.hpp
@@ -200,11 +200,11 @@ parallel_stable_sort <Iter_t, Compare>
 
 
     
-}; // end of constructor
+} // end of constructor
 
 //
 //****************************************************************************
-};//    End namespace stable_detail
+}//    End namespace stable_detail
 //****************************************************************************
 //
 
@@ -237,7 +237,7 @@ void parallel_stable_sort(Iter_t first, Iter_t last)
 {
     typedef bscu::compare_iter<Iter_t> Compare;
     stable_detail::parallel_stable_sort<Iter_t, Compare>(first, last);
-};
+}
 //
 //-----------------------------------------------------------------------------
 //  function : parallel_stable_sort
@@ -254,7 +254,7 @@ void parallel_stable_sort(Iter_t first, Iter_t last, uint32_t nthread)
 {
     typedef bscu::compare_iter<Iter_t> Compare;
     stable_detail::parallel_stable_sort<Iter_t, Compare>(first, last, nthread);
-};
+}
 //
 //-----------------------------------------------------------------------------
 //  function : parallel_stable_sort
@@ -271,7 +271,7 @@ template <class Iter_t, class Compare,
 void parallel_stable_sort(Iter_t first, Iter_t last, Compare comp)
 {
     stable_detail::parallel_stable_sort<Iter_t, Compare>(first, last, comp);
-};
+}
 
 //
 //-----------------------------------------------------------------------------
@@ -294,8 +294,8 @@ void parallel_stable_sort (Iter_t first, Iter_t last, Compare comp,
 }
 //
 //****************************************************************************
-};//    End namespace sort
-};//    End namespace boost
+}//    End namespace sort
+}//    End namespace boost
 //****************************************************************************
 //
 #endif

--- a/include/boost/sort/sample_sort/sample_sort.hpp
+++ b/include/boost/sort/sample_sort/sample_sort.hpp
@@ -124,22 +124,22 @@ struct sample_sort
 
     sample_sort(Iter_t first, Iter_t last)
     : sample_sort (first, last, Compare(), std::thread::hardware_concurrency(),
-                   nullptr, 0) { };
+                   nullptr, 0) { }
 
     sample_sort(Iter_t first, Iter_t last, Compare cmp)
     : sample_sort(first, last, cmp, std::thread::hardware_concurrency(),
-                  nullptr, 0) { };
+                  nullptr, 0) { }
 
     sample_sort(Iter_t first, Iter_t last, uint32_t num_thread)
-    : sample_sort(first, last, Compare(), num_thread, nullptr, 0) { };
+    : sample_sort(first, last, Compare(), num_thread, nullptr, 0) { }
 
     sample_sort(Iter_t first, Iter_t last, Compare cmp, uint32_t num_thread)
-    : sample_sort(first, last, cmp, num_thread, nullptr, 0) { };
+    : sample_sort(first, last, cmp, num_thread, nullptr, 0) { }
 
     sample_sort(Iter_t first, Iter_t last, Compare cmp, uint32_t num_thread,
                 range_buf range_buf_initial)
     : sample_sort(first, last, cmp, num_thread,
-                  range_buf_initial.first, range_buf_initial.size()) { };
+                  range_buf_initial.first, range_buf_initial.size()) { }
 
     void destroy_all(void);
     //
@@ -148,7 +148,7 @@ struct sample_sort
     /// @brief destructor of the class. The utility is to destroy the temporary
     ///        buffer used in the sorting process
     //-----------------------------------------------------------------------------
-    ~sample_sort(void) { destroy_all(); };
+    ~sample_sort(void) { destroy_all(); }
     //
     //-----------------------------------------------------------------------
     //  function : execute first
@@ -161,8 +161,8 @@ struct sample_sort
         {
             uninit_merge_level4(vrange_buf_ini[job], vv_range_it[job],
                             vv_range_buf[job], comp);
-        };
-    };
+        }
+    }
     //
     //-----------------------------------------------------------------------
     //  function : execute
@@ -175,8 +175,8 @@ struct sample_sort
         {
             merge_vector4(vrange_buf_ini[job], vrange_it_ini[job],
                             vv_range_buf[job], vv_range_it[job], comp);
-        };
-    };
+        }
+    }
     //
     //-----------------------------------------------------------------------
     //  function : first merge
@@ -193,7 +193,7 @@ struct sample_sort
         };
         for (uint32_t i = 0; i < nthread; ++i)
             vfuture[i].get();
-    };
+    }
     //
     //-----------------------------------------------------------------------
     //  function : final merge
@@ -206,10 +206,10 @@ struct sample_sort
         for (uint32_t i = 0; i < nthread; ++i)
         {
             vfuture[i] = std::async(std::launch::async, &this_t::execute, this);
-        };
+        }
         for (uint32_t i = 0; i < nthread; ++i)
             vfuture[i].get();
-    };
+    }
     //----------------------------------------------------------------------------
 };
 //                    End class sample_sort
@@ -259,7 +259,7 @@ sample_sort<Iter_t, Compare>
     {
         bss::spinsort<Iter_t, Compare>(first, last, comp);
         return;
-    };
+    }
 
     //------------------- check if sort --------------------------------------
     bool sw = true;
@@ -279,7 +279,7 @@ sample_sort<Iter_t, Compare>
         for (size_t i = 0; i < nelem2; ++i)
             swap(*(it1++), *(it2--));
         return;
-    };
+    }
 
     if (paux != nullptr)
     {
@@ -296,7 +296,7 @@ sample_sort<Iter_t, Compare>
         if (ptr == nullptr) throw std::bad_alloc();
         owner = true;
         global_buf = range_buf(ptr, ptr + nelem);
-    };
+    }
     //------------------------------------------------------------------------
     //                    PROCESS
     //------------------------------------------------------------------------
@@ -306,20 +306,20 @@ sample_sort<Iter_t, Compare>
     } catch (std::bad_alloc &)
     {
         error = true;
-    };
+    }
     if (not error)
     {
         first_merge();
         construct = true;
         final_merge();
-    };
+    }
     if (error)
     {
         destroy_all();
         throw std::bad_alloc();
-    };
+    }
 }
-;
+
 //
 //-----------------------------------------------------------------------------
 //  function : destroy_all
@@ -464,22 +464,22 @@ void sample_sort<Iter_t, Compare>::initial_configuration(void)
             if (nelem_range != 0)
             {
                 vv_range_it[k].push_back(vv_range_first[i][k]);
-            };
+            }
             nelem_interval += nelem_range;
-        };
+        }
 
         vrange_it_ini.emplace_back(it, it + nelem_interval);
         vrange_buf_ini.emplace_back(it_buf, it_buf + nelem_interval);
 
         it += nelem_interval;
         it_buf += nelem_interval;
-    };
+    }
 }
-;
+
 //
 //****************************************************************************
 }
-;
+
 //    End namespace sample_detail
 //****************************************************************************
 //
@@ -505,7 +505,7 @@ void sample_sort(Iter_t first, Iter_t last)
 {
     typedef compare_iter<Iter_t> Compare;
     sample_detail::sample_sort<Iter_t, Compare>(first, last);
-};
+}
 //
 //-----------------------------------------------------------------------------
 //  function : sample_sort
@@ -521,7 +521,7 @@ void sample_sort(Iter_t first, Iter_t last, uint32_t nthread)
 {
     typedef compare_iter<Iter_t> Compare;
     sample_detail::sample_sort<Iter_t, Compare>(first, last, nthread);
-};
+}
 //
 //-----------------------------------------------------------------------------
 //  function : sample_sort
@@ -537,7 +537,7 @@ template<class Iter_t, class Compare, bscu::enable_if_not_integral<Compare> * =
 void sample_sort(Iter_t first, Iter_t last, Compare comp)
 {
     sample_detail::sample_sort<Iter_t, Compare>(first, last, comp);
-};
+}
 //
 //-----------------------------------------------------------------------------
 //  function : sample_sort
@@ -554,11 +554,11 @@ template<class Iter_t, class Compare>
 void sample_sort(Iter_t first, Iter_t last, Compare comp, uint32_t nthread)
 {
     sample_detail::sample_sort<Iter_t, Compare>(first, last, comp, nthread);
-};
+}
 //
 //****************************************************************************
-};//    End namespace sort
-};//    End namespace boost
+}//    End namespace sort
+}//    End namespace boost
 //****************************************************************************
 //
 #endif

--- a/include/boost/sort/spinsort/spinsort.hpp
+++ b/include/boost/sort/spinsort/spinsort.hpp
@@ -134,7 +134,7 @@ static void insert_partial_sort (Iter1_t first, Iter1_t mid, Iter1_t last,
         *(viter[i - 1] + (i - 1)) = std::move(*(data + (i - 1)));
     };
 }
-;
+
 //-----------------------------------------------------------------------------
 //  function : check_stable_sort
 /// @brief check if the elements between first and last are osted or reverse
@@ -222,7 +222,7 @@ static bool check_stable_sort(const range<Iter1_t> &rng_data,
     };
     return true;
 }
-;
+
 //-----------------------------------------------------------------------------
 //  function : range_sort
 /// @brief this function divide r_input in two parts, sort it,and merge moving
@@ -297,7 +297,7 @@ static void range_sort(const range<Iter1_t> &range1,
 
     merge(range2, range_input1, range_input2, comp);
 }
-;
+
 //-----------------------------------------------------------------------------
 //  function : sort_range_sort
 /// @brief this sort elements using the range_sort function and receiving a
@@ -349,7 +349,7 @@ static void sort_range_sort(const range<Iter1_t> &rng_data,
         move_forward(rng_data, rng_buffer);
     };
 }
-;
+
 //
 //############################################################################
 //                                                                          ##
@@ -423,6 +423,7 @@ public:
         if (owner and ptr != nullptr) std::free (ptr);
     };
 };
+
 //----------------------------------------------------------------------------
 //        End of class spinsort
 //----------------------------------------------------------------------------
@@ -532,10 +533,10 @@ spinsort <Iter_t, Compare>
         range_sort(range_1, range_2, comp, nlevel);
         merge_half(range_input, range_aux, range_2, comp);
     };
-};
+}
 
 //****************************************************************************
-};//    End namepspace spin_detail
+}//    End namepspace spin_detail
 //****************************************************************************
 //
 namespace bsc = boost::sort::common;
@@ -552,7 +553,7 @@ template <class Iter_t, class Compare = compare_iter<Iter_t>>
 inline void spinsort (Iter_t first, Iter_t last, Compare comp = Compare())
 {
     spin_detail::spinsort <Iter_t, Compare> (first, last, comp);
-};
+}
 
 template <class Iter_t, class Compare = compare_iter<Iter_t>>
 inline void indirect_spinsort (Iter_t first, Iter_t last,
@@ -561,11 +562,11 @@ inline void indirect_spinsort (Iter_t first, Iter_t last,
     typedef typename std::vector<Iter_t>::iterator itx_iter;
     typedef common::less_ptr_no_null <Iter_t, Compare> itx_comp;
     common::indirect_sort (spinsort<itx_iter, itx_comp>, first, last, comp);
-};
+}
 
 //****************************************************************************
-};//    End namespace sort
-};//    End namepspace boost
+}//    End namespace sort
+}//    End namepspace boost
 //****************************************************************************
 //
 #endif


### PR DESCRIPTION
Quite interested in using block_indirect_sort for a current project that concerns rather large arrays.

However our organisation has some conventions (policies?) about compiler flags which includes gcc --pedantic.
And since boost::sort is templated we'd need to touch various modules to relax the compiler flags in various ways.

```
$ g++ --version
g++ (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

```
$ g++ test_block_indirect_sort.cpp -I $(pwd)/../include --pedantic
In file included from /home/nigels/dev/sort/test/../include/boost/sort/insert_sort/insert_sort.hpp:21,
                 from /home/nigels/dev/sort/test/../include/boost/sort/spinsort/spinsort.hpp:25,
                 from /home/nigels/dev/sort/test/../include/boost/sort/sort.hpp:17,
                 from test_block_indirect_sort.cpp:22:
/home/nigels/dev/sort/test/../include/boost/sort/common/util/traits.hpp:115:6: warning: extra ‘;’ [-Wpedantic]
  115 |     };
      |      ^
      |      -
In file included from /home/nigels/dev/sort/test/../include/boost/sort/block_indirect_sort/blk_detail/backbone.hpp:25,
                 from /home/nigels/dev/sort/test/../include/boost/sort/block_indirect_sort/blk_detail/merge_blocks.hpp:22,
                 from /home/nigels/dev/sort/test/../include/boost/sort/block_indirect_sort/block_indirect_sort.hpp:22,
                 from /home/nigels/dev/sort/test/../include/boost/sort/sort.hpp:20,
                 from test_block_indirect_sort.cpp:22:
/home/nigels/dev/sort/test/../include/boost/sort/common/stack_cnc.hpp:102:6: warning: extra ‘;’ [-Wpedantic]
  102 |     };
      |      ^
      |      -
/home/nigels/dev/sort/test/../include/boost/sort/common/stack_cnc.hpp:135:6: warning: extra ‘;’ [-Wpedantic]
  135 |     };
      |      ^
      |      -
```

So I took a bit of a quick look at the block_indirect_sort and what it might require to make `gcc --pedantic` happy.
In my understanding semicolons are needed after a lambda function, struct or class, but not for if/while/for blocks, functions or namespaces.

It does seem that other code linters may well also fuss over this and while the extra semicolons seem harmless to me, they're not what I'm used to looking at, to be honest.

So as a conversation starter with boost::sort maintainers, is this sort of change something likely to be accepted as a contribution?  I'm open to covering all the headers, but this initial effort seemed like enough to reduce some tooling friction for block_indirect_sort.