### PR TITLE
pdqsort: Resolve MS compiler warnings about assigning size_t to unsigned char

### DIFF
--- a/include/boost/sort/pdqsort/pdqsort.hpp
+++ b/include/boost/sort/pdqsort/pdqsort.hpp
@@ -243,7 +243,7 @@ namespace pdqsort_detail {
                         offsets_l[num_l] = i++; num_l += !comp(*first, pivot); ++first;
                     }
                 } else {
-                    for (size_t i = 0; i < left_split;) {
+                    for (unsigned char i = 0; i < static_cast<unsigned char>(left_split);) {
                         offsets_l[num_l] = i++; num_l += !comp(*first, pivot); ++first;
                     }
                 }

--- a/include/boost/sort/pdqsort/pdqsort.hpp
+++ b/include/boost/sort/pdqsort/pdqsort.hpp
@@ -232,7 +232,7 @@ namespace pdqsort_detail {
 
                 // Fill the offset blocks.
                 if (left_split >= block_size) {
-                    for (size_t i = 0; i < block_size;) {
+                    for (unsigned char i = 0; i < static_cast<unsigned char>(block_size);) {
                         offsets_l[num_l] = i++; num_l += !comp(*first, pivot); ++first;
                         offsets_l[num_l] = i++; num_l += !comp(*first, pivot); ++first;
                         offsets_l[num_l] = i++; num_l += !comp(*first, pivot); ++first;
@@ -249,7 +249,7 @@ namespace pdqsort_detail {
                 }
 
                 if (right_split >= block_size) {
-                    for (size_t i = 0; i < block_size;) {
+                    for (unsigned char i = 0; i < static_cast<unsigned char>(block_size);) {
                         offsets_r[num_r] = ++i; num_r += comp(*--last, pivot);
                         offsets_r[num_r] = ++i; num_r += comp(*--last, pivot);
                         offsets_r[num_r] = ++i; num_r += comp(*--last, pivot);
@@ -260,7 +260,7 @@ namespace pdqsort_detail {
                         offsets_r[num_r] = ++i; num_r += comp(*--last, pivot);
                     }
                 } else {
-                    for (size_t i = 0; i < right_split;) {
+                    for (unsigned char i = 0; i < static_cast<unsigned char>(right_split);) {
                         offsets_r[num_r] = ++i; num_r += comp(*--last, pivot);
                     }
                 }


### PR DESCRIPTION
We're seeing lots of MS compiler warnings about pdqsort.
It looks like using unsigned char for the loop variable is a reasonable alternative.

```
include\boost-1_82\boost/sort/pdqsort/pdqsort.hpp(237,1): warning C4267: '=': conversion from 'size_t' to 'unsigned char', possible loss of data 
include\boost-1_82\boost/sort/pdqsort/pdqsort.hpp(238,1): warning C4267: '=': conversion from 'size_t' to 'unsigned char', possible loss of data 
include\boost-1_82\boost/sort/pdqsort/pdqsort.hpp(239,1): warning C4267: '=': conversion from 'size_t' to 'unsigned char', possible loss of data 
include\boost-1_82\boost/sort/pdqsort/pdqsort.hpp(240,1): warning C4267: '=': conversion from 'size_t' to 'unsigned char', possible loss of data 
include\boost-1_82\boost/sort/pdqsort/pdqsort.hpp(241,1): warning C4267: '=': conversion from 'size_t' to 'unsigned char', possible loss of data 
include\boost-1_82\boost/sort/pdqsort/pdqsort.hpp(242,1): warning C4267: '=': conversion from 'size_t' to 'unsigned char', possible loss of data 
include\boost-1_82\boost/sort/pdqsort/pdqsort.hpp(243,1): warning C4267: '=': conversion from 'size_t' to 'unsigned char', possible loss of data 
include\boost-1_82\boost/sort/pdqsort/pdqsort.hpp(247,1): warning C4267: '=': conversion from 'size_t' to 'unsigned char', possible loss of data 
include\boost-1_82\boost/sort/pdqsort/pdqsort.hpp(253,1): warning C4267: '=': conversion from 'size_t' to 'unsigned char', possible loss of data 
include\boost-1_82\boost/sort/pdqsort/pdqsort.hpp(254,1): warning C4267: '=': conversion from 'size_t' to 'unsigned char', possible loss of data 
include\boost-1_82\boost/sort/pdqsort/pdqsort.hpp(255,1): warning C4267: '=': conversion from 'size_t' to 'unsigned char', possible loss of data 
include\boost-1_82\boost/sort/pdqsort/pdqsort.hpp(256,1): warning C4267: '=': conversion from 'size_t' to 'unsigned char', possible loss of data 
include\boost-1_82\boost/sort/pdqsort/pdqsort.hpp(257,1): warning C4267: '=': conversion from 'size_t' to 'unsigned char', possible loss of data 
include\boost-1_82\boost/sort/pdqsort/pdqsort.hpp(258,1): warning C4267: '=': conversion from 'size_t' to 'unsigned char', possible loss of data 
include\boost-1_82\boost/sort/pdqsort/pdqsort.hpp(259,1): warning C4267: '=': conversion from 'size_t' to 'unsigned char', possible loss of data 
include\boost-1_82\boost/sort/pdqsort/pdqsort.hpp(260,1): warning C4267: '=': conversion from 'size_t' to 'unsigned char', possible loss of data 
include\boost-1_82\boost/sort/pdqsort/pdqsort.hpp(264,1): warning C4267: '=': conversion from 'size_t' to 'unsigned char', possible loss of data 
```