### PR TITLE
Benchmark Test Correction for boost::sort

### DIFF
--- a/benchmark/single/benchmark_numbers.cpp
+++ b/benchmark/single/benchmark_numbers.cpp
@@ -182,9 +182,9 @@ void Generator_sorted_middle (size_t n_last)
         std::cout << "Error in the input file\n";
         return;
     };
-    for (size_t i = NELEM; i < A.size(); ++i)
-        B.push_back(std::move(A[i]));
-    A.resize(NELEM);
+    for (size_t i = NELEM; i < A.size (); ++i)
+        B.push_back (std::move (A[i]));
+    A.resize ( NELEM);
 
     std::sort (A.begin (), A.end ());
     size_t step = NELEM / n_last;
@@ -239,20 +239,20 @@ void Generator_reverse_sorted_middle (size_t n_last)
         return;
     };
     for (size_t i = NELEM; i < A.size (); ++i)
-        B.push_back (std::move(A[i]));
+        B.push_back (std::move (A[i]));
     A.resize ( NELEM);
 
     std::sort (A.begin (), A.end ());
     size_t step = NELEM / n_last;
     size_t pos = 0;
     for (size_t i = 0; i < (NELEM >> 1); ++i)
-        std::swap(A[i], A[NELEM - 1 - i]);
+        std::swap (A[i], A[NELEM - 1 - i]);
 
     for (size_t i = 0; i < B.size (); ++i, pos += step)
     {
-        C.push_back (B[i]); 
+        C.push_back (B[i]);
         for (size_t k = 0; k < step; ++k)
-            C.push_back (A.at(pos + k)); 
+            C.push_back (A.at(pos + k));
     };
     while (pos < A.size ())
         C.push_back (A[pos++]);

--- a/benchmark/single/benchmark_numbers.cpp
+++ b/benchmark/single/benchmark_numbers.cpp
@@ -175,33 +175,31 @@ void Generator_sorted_end (size_t n_last)
 void Generator_sorted_middle (size_t n_last)
 {
     vector<uint64_t> A, B, C;
-    A.reserve (NELEM);
-    A.clear ();
-    if (fill_vector_uint64 ("input.bin", A, NELEM + n_last) != 0)
+    A.reserve(NELEM);
+    A.clear();
+    if (fill_vector_uint64("input.bin", A, NELEM + n_last) != 0)
     {
         std::cout << "Error in the input file\n";
         return;
     };
-    for (size_t i = NELEM; i < A.size (); ++i)
-        B.push_back (std::move (A[i]));
-    A.resize ( NELEM);
-    for (size_t i = 0; i < (NELEM >> 1); ++i)
-        std::swap (A[i], A[NELEM - 1 - i]);
+    for (size_t i = NELEM; i < A.size(); ++i)
+        B.push_back(std::move(A[i]));
+    A.resize(NELEM);
 
-    std::sort (A.begin (), A.end ());
-    size_t step = NELEM / n_last + 1;
+    std::sort(A.begin(), A.end());
+    size_t step = NELEM / n_last;
     size_t pos = 0;
 
-    for (size_t i = 0; i < B.size (); ++i, pos += step)
+    for (size_t i = 0; i < B.size(); ++i, pos += step)
     {
-        C.push_back (B[i]);
+        C.push_back(B[i]);
         for (size_t k = 0; k < step; ++k)
-            C.push_back (A[pos + k]);
+            C.push_back(A.at(pos + k));
     };
-    while (pos < A.size ())
-        C.push_back (A[pos++]);
+    while (pos < A.size())
+        C.push_back(A[pos++]);
     A = C;
-    Test<uint64_t, std::less<uint64_t>> (A);
+    Test<uint64_t, std::less<uint64_t>>(A);
 }
 ;
 void Generator_reverse_sorted (void)
@@ -233,33 +231,33 @@ void Generator_reverse_sorted_end (size_t n_last)
 void Generator_reverse_sorted_middle (size_t n_last)
 {
     vector<uint64_t> A, B, C;
-    A.reserve (NELEM);
-    A.clear ();
-    if (fill_vector_uint64 ("input.bin", A, NELEM + n_last) != 0)
+    A.reserve(NELEM);
+    A.clear();
+    if (fill_vector_uint64("input.bin", A, NELEM + n_last) != 0)
     {
         std::cout << "Error in the input file\n";
         return;
     };
-    for (size_t i = NELEM; i < A.size (); ++i)
-        B.push_back (std::move (A[i]));
-    A.resize ( NELEM);
-    for (size_t i = 0; i < (NELEM >> 1); ++i)
-        std::swap (A[i], A[NELEM - 1 - i]);
+    for (size_t i = NELEM; i < A.size(); ++i)
+        B.push_back(std::move(A[i]));
+    A.resize(NELEM);
 
-    std::sort (A.begin (), A.end ());
-    size_t step = NELEM / n_last + 1;
+    std::sort(A.begin(), A.end());
+    size_t step = NELEM / n_last;
     size_t pos = 0;
+    for (size_t i = 0; i < (NELEM >> 1); ++i)
+        std::swap(A[i], A[NELEM - 1 - i]);
 
-    for (size_t i = 0; i < B.size (); ++i, pos += step)
+    for (size_t i = 0; i < B.size(); ++i, pos += step)
     {
-        C.push_back (B[i]);
+        C.push_back(B[i]); 
         for (size_t k = 0; k < step; ++k)
-            C.push_back (A[pos + k]);
+            C.push_back(A.at(pos + k)); 
     };
-    while (pos < A.size ())
-        C.push_back (A[pos++]);
+    while (pos < A.size())
+        C.push_back(A[pos++]);
     A = C;
-    Test<uint64_t, std::less<uint64_t>> (A);
+    Test<uint64_t, std::less<uint64_t>>(A);
 };
 
 

--- a/benchmark/single/benchmark_numbers.cpp
+++ b/benchmark/single/benchmark_numbers.cpp
@@ -175,9 +175,9 @@ void Generator_sorted_end (size_t n_last)
 void Generator_sorted_middle (size_t n_last)
 {
     vector<uint64_t> A, B, C;
-    A.reserve(NELEM);
-    A.clear();
-    if (fill_vector_uint64("input.bin", A, NELEM + n_last) != 0)
+    A.reserve (NELEM);
+    A.clear ();
+    if (fill_vector_uint64 ("input.bin", A, NELEM + n_last) != 0)
     {
         std::cout << "Error in the input file\n";
         return;
@@ -186,20 +186,20 @@ void Generator_sorted_middle (size_t n_last)
         B.push_back(std::move(A[i]));
     A.resize(NELEM);
 
-    std::sort(A.begin(), A.end());
+    std::sort (A.begin (), A.end ());
     size_t step = NELEM / n_last;
     size_t pos = 0;
 
-    for (size_t i = 0; i < B.size(); ++i, pos += step)
+    for (size_t i = 0; i < B.size (); ++i, pos += step)
     {
-        C.push_back(B[i]);
+        C.push_back (B[i]);
         for (size_t k = 0; k < step; ++k)
-            C.push_back(A.at(pos + k));
+            C.push_back (A.at(pos + k));
     };
-    while (pos < A.size())
-        C.push_back(A[pos++]);
+    while (pos < A.size ())
+        C.push_back (A[pos++]);
     A = C;
-    Test<uint64_t, std::less<uint64_t>>(A);
+    Test<uint64_t, std::less<uint64_t>> (A);
 }
 ;
 void Generator_reverse_sorted (void)
@@ -231,33 +231,33 @@ void Generator_reverse_sorted_end (size_t n_last)
 void Generator_reverse_sorted_middle (size_t n_last)
 {
     vector<uint64_t> A, B, C;
-    A.reserve(NELEM);
-    A.clear();
-    if (fill_vector_uint64("input.bin", A, NELEM + n_last) != 0)
+    A.reserve (NELEM);
+    A.clear ();
+    if (fill_vector_uint64 ("input.bin", A, NELEM + n_last) != 0)
     {
         std::cout << "Error in the input file\n";
         return;
     };
-    for (size_t i = NELEM; i < A.size(); ++i)
-        B.push_back(std::move(A[i]));
-    A.resize(NELEM);
+    for (size_t i = NELEM; i < A.size (); ++i)
+        B.push_back (std::move(A[i]));
+    A.resize ( NELEM);
 
-    std::sort(A.begin(), A.end());
+    std::sort (A.begin (), A.end ());
     size_t step = NELEM / n_last;
     size_t pos = 0;
     for (size_t i = 0; i < (NELEM >> 1); ++i)
         std::swap(A[i], A[NELEM - 1 - i]);
 
-    for (size_t i = 0; i < B.size(); ++i, pos += step)
+    for (size_t i = 0; i < B.size (); ++i, pos += step)
     {
-        C.push_back(B[i]); 
+        C.push_back (B[i]); 
         for (size_t k = 0; k < step; ++k)
-            C.push_back(A.at(pos + k)); 
+            C.push_back (A.at(pos + k)); 
     };
-    while (pos < A.size())
-        C.push_back(A[pos++]);
+    while (pos < A.size ())
+        C.push_back (A[pos++]);
     A = C;
-    Test<uint64_t, std::less<uint64_t>>(A);
+    Test<uint64_t, std::less<uint64_t>> (A);
 };
 
 


### PR DESCRIPTION
In reviewing the benchmark_numbers.cpp file, I noticed that the functions Generator_sorted_middle and Generator_reversed_sorted_middle have identical definitions. Additionally, certain parts of these functions' code lack coherence. I am proposing a resolution for these issues.

Problems Identified:

1. The method Generator_reversed_sorted_middle currently sorts the elements after swapping them, contradicting the intention of a reversed sort ( l. 246 - 247 ). In Generator_reversed_sorted_middle the swapping also happens, with no use afterwards ( l. 188 - 189).

2. The Generator_sorted_middle and Generator_reversed_sorted_middle functions generate more elements compared to other methods. For instance, the Generator_sorted_middle function generates 100200000 elements when running sorted + 0.1% end, while other functions generate only 100100000. This unequal element generation inhibits fair comparison between different algorithms.

3. The algorithm execution leads to an out of bound access at lines 199 and 257.

Proposed Solution:
I have made adjustments to address these issues. The changes lead to more consistent and accurate benchmark tests between sorting algorithms. I look forward to feedback on my proposed revisions.