### PR TITLE
block_indirect_sort: Lambda capture this rather than direct counter reference

### DIFF
--- a/include/boost/sort/block_indirect_sort/block_indirect_sort.hpp
+++ b/include/boost/sort/block_indirect_sort/block_indirect_sort.hpp
@@ -258,10 +258,10 @@ block_indirect_sort<Block_size, Group_size, Iter_t, Compare>
 
         // Insert the first work in the stack
         bscu::atomic_write(counter, 1);
-        function_t f1 = [&]( )
+        function_t f1 = [this]( )
         {
             start_function ( );
-            bscu::atomic_sub (counter, 1);
+            bscu::atomic_sub (this->counter, 1);
         };
         bk.works.emplace_back(f1);
 


### PR DESCRIPTION
[cppcheck](https://cppcheck.sourceforge.io/) has the follow complaint about block_indirect_sort:

```
/home/nigels/dev/boost/libs/sort/include/boost/sort/block_indirect_sort/block_indirect_sort.hpp:262:23: error: Using lambda that captures local variable 'counter' that is out of scope. [invalidLifetime]
        function_t f1 = [&]( )
                      ^
/home/nigels/dev/boost/libs/sort/include/boost/sort/block_indirect_sort/block_indirect_sort.hpp:265:31: note: Lambda captures variable by reference here.
            bscu::atomic_sub (counter, 1);
                              ^
/home/nigels/dev/boost/libs/sort/include/boost/sort/block_indirect_sort/blk_detail/move_blocks.hpp:166:14: note: Variable created here.
    atomic_t counter(0);
             ^
/home/nigels/dev/boost/libs/sort/include/boost/sort/block_indirect_sort/block_indirect_sort.hpp:262:23: note: Using lambda that captures local variable 'counter' that is out of scope.
        function_t f1 = [&]( )
                      ^
/home/nigels/dev/boost/libs/sort/include/boost/sort/block_indirect_sort/block_indirect_sort.hpp:267:31: error: Using lambda that captures local variable 'counter' that is out of scope. [invalidLifetime]
        bk.works.emplace_back(f1);
                              ^
/home/nigels/dev/boost/libs/sort/include/boost/sort/block_indirect_sort/block_indirect_sort.hpp:265:31: note: Lambda captures variable by reference here.
            bscu::atomic_sub (counter, 1);
                              ^
/home/nigels/dev/boost/libs/sort/include/boost/sort/block_indirect_sort/blk_detail/move_blocks.hpp:166:14: note: Variable created here.
    atomic_t counter(0);
             ^
/home/nigels/dev/boost/libs/sort/include/boost/sort/block_indirect_sort/block_indirect_sort.hpp:267:31: note: Using lambda that captures local variable 'counter' that is out of scope.
        bk.works.emplace_back(f1);
```

Which seems more legitimate a _warning_ than an _error_ to me, to be honest.

However, changing the lambda capture to _this_ seems to resolve the cppcheck warning.

To reproduce:

```
$ cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DBUILD_TESTING=Y -DCMAKE_CXX_CPPCHECK=cppcheck -DBOOST_INCLUDE_LIBRARIES=sort
...
$ ninja
...
```