### PR TITLE
merge_blocks: const pos_index1, pos_index2 and pos_index3 to resolve cppcheck false alarm

### DIFF
--- a/include/boost/sort/block_indirect_sort/blk_detail/merge_blocks.hpp
+++ b/include/boost/sort/block_indirect_sort/blk_detail/merge_blocks.hpp
@@ -177,8 +177,8 @@ struct merge_blocks
 //-------------------------------------------------------------------------
 template<uint32_t Block_size, uint32_t Group_size, class Iter_t, class Compare>
 merge_blocks<Block_size, Group_size, Iter_t, Compare>
-::merge_blocks( backbone_t &bkb, size_t pos_index1, size_t pos_index2,
-                size_t pos_index3) : bk(bkb)
+::merge_blocks( backbone_t &bkb, const size_t pos_index1, const size_t pos_index2,
+                const size_t pos_index3) : bk(bkb)
 {
     size_t nblock1 = pos_index2 - pos_index1;
     size_t nblock2 = pos_index3 - pos_index2;


### PR DESCRIPTION
[cppcheck](https://cppcheck.sourceforge.io/) complains about a potential _Out of bounds access_ in merge_blocks implementation:

```
/home/nigels/dev/boost/libs/sort/include/boost/sort/block_indirect_sort/blk_detail/merge_blocks.hpp:207:19: error: Out of bounds access in expression 'vpos2.back()' because 'vpos2' is empty. [containerOutOfBounds]
    if (vpos2.back().pos() == (bk.nblock - 1)
                  ^
/home/nigels/dev/boost/libs/sort/include/boost/sort/block_indirect_sort/blk_detail/merge_blocks.hpp:200:35: note: Assuming condition is false
    for (size_t i = pos_index2; i < pos_index3; ++i)
                                  ^
/home/nigels/dev/boost/libs/sort/include/boost/sort/block_indirect_sort/blk_detail/merge_blocks.hpp:207:19: note: Access out of bounds
    if (vpos2.back().pos() == (bk.nblock - 1)
                  ^
```

However.  Changing the three index parameters to `const` seems sufficient to resolve the cppcheck (false) error.
Seems like a low-risk and agreeable workaround.