### PR TITLE
cmake: Add standalone build support for building and running unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,16 +15,9 @@ else()
 endif()
 
 # Test coverage in stand-alone mode requires boost dependencies
-
-if(NOT BOOST_SUPERPROJECT_VERSION)
-  if(BUILD_TESTING)
-    set(Boost_DEBUG ON)
-    find_package(Boost 1.85 REQUIRED COMPONENTS core range included_test_exec_monitor)
-    if(NOT Boost_FOUND)
-      message(STATUS "Boost 1.85 (or later) is required")
-      return()
-    endif()
-  endif()
+if(BUILD_TESTING AND NOT BOOST_SUPERPROJECT_VERSION)
+  set(Boost_DEBUG ON)
+  find_package(Boost 1.85 REQUIRED COMPONENTS core range included_test_exec_monitor)
 endif()
 
 add_library(boost_sort INTERFACE)
@@ -42,7 +35,6 @@ target_link_libraries(boost_sort
 )
 
 # Testing
-
 if(BUILD_TESTING AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/CMakeLists.txt")
 
   if(NOT BOOST_SUPERPROJECT_VERSION)
@@ -52,5 +44,7 @@ if(BUILD_TESTING AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/CMakeLists.txt")
     add_dependencies(check tests)
   endif()
 
-  add_subdirectory(test)
+  # Follow the Boost convention: don't build test targets by default,
+  # and only when explicitly requested by building target tests
+  add_subdirectory(test EXCLUDE_FROM_ALL)
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,11 +26,6 @@ function(boost_sort_add_test name source)
   set(pname "${PREFIX}${name}")
   add_executable(${pname} ${source})
   target_link_libraries(${pname} ${LINK_LIBRARIES})
-
-  # Follow the Boost convention: don't build test targets by default,
-  # and only when explicitly requested by building target tests
-  set_target_properties(${pname} PROPERTIES EXCLUDE_FROM_ALL ON)
-
   add_test(NAME ${pname} COMMAND ${pname})
   add_dependencies(tests ${pname})
 endfunction()


### PR DESCRIPTION
The CMakeLists.txt currently supports the "superproject" boost build,
but does not work stand alone.

This change adds support for a stand-alone build of boost::sort, using the cmake method of detecting an existing boost installation.

`-DBUILD_TESTING=Y` can be used for opting into the test coverage.

The default `all` target will not build anything, since sort is a header-only library.
The `tests` target can be used to build the unit tests.
The `check` target can be used to run the unit tests, building if necessary.

```
$ PATH=/opt/cmake-3.10.0-Linux-x86_64/bin:$PATH cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTING=Y -DCMAKE_CXX_COMPILER=clang++-18 && ninja check
-- Using cmake version 3.10.0
-- Found Boost 1.89.0 at /opt/boost-1.89.0/lib/cmake/Boost-1.89.0
--   Requested configuration: QUIET REQUIRED COMPONENTS core;range;included_test_exec_monitor
-- BoostConfig: find_package(boost_headers 1.89.0 EXACT CONFIG REQUIRED QUIET HINTS /opt/boost-1.89.0/lib/cmake)
-- Found boost_headers 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_headers-1.89.0
-- BoostConfig: find_package(boost_core 1.89.0 EXACT CONFIG REQUIRED QUIET HINTS /opt/boost-1.89.0/lib/cmake)
-- Found boost_core 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_core-1.89.0
-- Found boost_assert 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_assert-1.89.0
-- Found boost_config 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_config-1.89.0
-- Found boost_static_assert 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_static_assert-1.89.0
-- Found boost_throw_exception 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_throw_exception-1.89.0
-- BoostConfig: find_package(boost_range 1.89.0 EXACT CONFIG REQUIRED QUIET HINTS /opt/boost-1.89.0/lib/cmake)
-- Found boost_range 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_range-1.89.0
-- Found boost_array 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_array-1.89.0
-- Found boost_concept_check 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_concept_check-1.89.0
-- Found boost_preprocessor 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_preprocessor-1.89.0
-- Found boost_type_traits 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_type_traits-1.89.0
-- Found boost_container_hash 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_container_hash-1.89.0
-- Found boost_describe 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_describe-1.89.0
-- Found boost_mp11 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_mp11-1.89.0
-- Found boost_conversion 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_conversion-1.89.0
-- Found boost_smart_ptr 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_smart_ptr-1.89.0
-- Found boost_detail 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_detail-1.89.0
-- Found boost_iterator 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_iterator-1.89.0
-- Found boost_fusion 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_fusion-1.89.0
-- Found boost_function_types 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_function_types-1.89.0
-- Found boost_mpl 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_mpl-1.89.0
-- Found boost_predef 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_predef-1.89.0
-- Found boost_utility 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_utility-1.89.0
-- Found boost_io 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_io-1.89.0
-- Found boost_tuple 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_tuple-1.89.0
-- Found boost_typeof 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_typeof-1.89.0
-- Found boost_functional 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_functional-1.89.0
-- Found boost_function 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_function-1.89.0
-- Found boost_bind 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_bind-1.89.0
-- Found boost_optional 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_optional-1.89.0
-- Found boost_regex 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_regex-1.89.0
-- BoostConfig: find_package(boost_included_test_exec_monitor 1.89.0 EXACT CONFIG REQUIRED QUIET HINTS /opt/boost-1.89.0/lib/cmake)
-- Found boost_included_test_exec_monitor 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_included_test_exec_monitor-1.89.0
-- Found boost_algorithm 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_algorithm-1.89.0
-- Found boost_exception 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_exception-1.89.0
-- Found boost_unordered 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_unordered-1.89.0
-- Found boost_numeric_conversion 1.89.0 at /opt/boost-1.89.0/lib/cmake/boost_numeric_conversion-1.89.0
-- Boost 1.85 found.
-- Found Boost components:
   core;range;included_test_exec_monitor
-- Configuring done
-- Generating done
-- Build files have been written to: /home/nigels/dev/boost/libs/sort/build
[1/1] cd /home/nigels/dev/boost/libs/sort/build && /opt/cmake-3.10.0-Linux-x86_64/bin/ctest --output-on-failure -C Release
Test project /home/nigels/dev/boost/libs/sort/build
      Start  1: boost_sort_float_sort_test
 1/11 Test  #1: boost_sort_float_sort_test .............   Passed    0.62 sec
      Start  2: boost_sort_integer_sort_test
 2/11 Test  #2: boost_sort_integer_sort_test ...........   Passed    0.03 sec
      Start  3: boost_sort_sort_detail_test
 3/11 Test  #3: boost_sort_sort_detail_test ............   Passed    0.00 sec
      Start  4: boost_sort_string_sort_test
 4/11 Test  #4: boost_sort_string_sort_test ............   Passed    0.08 sec
      Start  5: boost_sort_test_block_indirect_sort
 5/11 Test  #5: boost_sort_test_block_indirect_sort ....   Passed    0.89 sec
      Start  6: boost_sort_test_flat_stable_sort
 6/11 Test  #6: boost_sort_test_flat_stable_sort .......   Passed    0.21 sec
      Start  7: boost_sort_test_insert_sort
 7/11 Test  #7: boost_sort_test_insert_sort ............   Passed    0.02 sec
      Start  8: boost_sort_test_parallel_stable_sort
 8/11 Test  #8: boost_sort_test_parallel_stable_sort ...   Passed    0.97 sec
      Start  9: boost_sort_test_pdqsort
 9/11 Test  #9: boost_sort_test_pdqsort ................   Passed    0.14 sec
      Start 10: boost_sort_test_sample_sort
10/11 Test #10: boost_sort_test_sample_sort ............   Passed    0.90 sec
      Start 11: boost_sort_test_spinsort
11/11 Test #11: boost_sort_test_spinsort ...............   Passed    0.20 sec

100% tests passed, 0 tests failed out of 11

Total Test time (real) =   4.06 sec
```