### PR TITLE
Drone: drone.sh

### DIFF
--- a/.drone/drone.sh
+++ b/.drone/drone.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -ex
+export TRAVIS_BUILD_DIR=$(pwd)
+export DRONE_BUILD_DIR=$(pwd)
+export TRAVIS_BRANCH=$DRONE_BRANCH
+export VCS_COMMIT_ID=$DRONE_COMMIT
+export GIT_COMMIT=$DRONE_COMMIT
+export REPO_NAME=$DRONE_REPO
+export PATH=~/.local/bin:/usr/local/bin:$PATH
+
+echo '==================================> BEFORE_INSTALL'
+
+. .drone/before-install.sh
+
+echo '==================================> INSTALL'
+
+BOOST_BRANCH=develop && [ "$TRAVIS_BRANCH" == "master" ] && BOOST_BRANCH=master || true
+cd ..
+git clone -b $BOOST_BRANCH https://github.com/boostorg/boost.git boost-root
+cd boost-root
+git submodule update --init tools/build
+git submodule update --init libs/config
+git submodule update --init tools/boostdep
+cp -r $TRAVIS_BUILD_DIR/* libs/sort
+python tools/boostdep/depinst/depinst.py sort
+./bootstrap.sh
+./b2 headers
+
+echo '==================================> BEFORE_SCRIPT'
+
+. $DRONE_BUILD_DIR/.drone/before-script.sh
+
+echo '==================================> SCRIPT'
+
+./b2 libs/sort/test toolset=$TOOLSET cxxstd=$CXXSTD
+
+echo '==================================> AFTER_SUCCESS'
+
+. $DRONE_BUILD_DIR/.drone/after-success.sh


### PR DESCRIPTION
Most boost drone configurations call the main script `.drone/drone.sh`.   A few of the early deployments used `.drone/boost.sh`.

To enable smart defaults it would be convenient to standardize on a name: `.drone/drone.sh`. 

Multi-step process:

1. Merge this copy of `drone.sh`

2. After 2 weeks, the defaults will change.  In the event you haven't yet merged this PR, drone might stop working, but that can be easily fixed by merging this PR.

3. After 2 months (just to be careful) go ahead and delete your copy of `.drone/boost.sh` .    The relevant file will be  `.drone/drone.sh`.